### PR TITLE
#161176677 Fix Back Arrow Redirect to GuestHouse Details 

### DIFF
--- a/src/components/Timeline/RoomsGeomWrapper/BedGeomWrapper/__tests__/__snapshots__/BedGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/BedGeomWrapper/__tests__/__snapshots__/BedGeomWrapper.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<BedGeomWrapper /> renders properly 1`] = `
 >
   <TripGeometry
     key="trip-id-1"
-    timelineStartDate={"2018-09-30T23:00:00.000Z"}
+    timelineStartDate={"2018-09-30T21:00:00.000Z"}
     timelineViewType="month"
     trip={
       Object {

--- a/src/components/Timeline/RoomsGeomWrapper/RoomGeomWrapper/__tests__/__snapshots__/RoomGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/RoomGeomWrapper/__tests__/__snapshots__/RoomGeomWrapper.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`<RoomGeomWrapper /> renders properly 1`] = `
     className="room-status-bar item-row"
   />
   <BedGeomWrapper
-    timelineStartDate={"2018-09-30T23:00:00.000Z"}
+    timelineStartDate={"2018-09-30T21:00:00.000Z"}
     timelineViewType="month"
     tripDayWidth={31}
   />

--- a/src/components/Timeline/RoomsGeomWrapper/__tests__/__snapshots__/RoomsGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/__tests__/__snapshots__/RoomsGeomWrapper.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`<RoomsGeomWrapper /> renders properly 1`] = `
     }
     key="room-id-1"
     status={false}
-    timelineStartDate={"2018-09-30T23:00:00.000Z"}
+    timelineStartDate={"2018-09-30T21:00:00.000Z"}
     timelineViewType="month"
     tripDayWidth={31}
   />

--- a/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
+++ b/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
@@ -116,7 +116,7 @@ exports[`<Timeline /> renders correctly 1`] = `
         key="16"
       />
       <div
-        className="timeline__segment  month-view"
+        className="timeline__segment current month-view"
         data-segment-label="18"
         key="17"
       />
@@ -187,7 +187,7 @@ exports[`<Timeline /> renders correctly 1`] = `
       />
       <RoomsGeomWrapper
         rooms={Array []}
-        timelineStartDate={"2018-09-30T23:00:00.000Z"}
+        timelineStartDate={"2018-09-30T21:00:00.000Z"}
         timelineViewType="month"
         tripDayWidth={0}
       />
@@ -263,7 +263,7 @@ exports[`<Timeline /> renders the weekly view correctly 1`] = `
       />
       <RoomsGeomWrapper
         rooms={Array []}
-        timelineStartDate={"2018-09-30T23:00:00.000Z"}
+        timelineStartDate={"2018-09-30T21:00:00.000Z"}
         timelineViewType="week"
         tripDayWidth={0}
       />
@@ -364,7 +364,7 @@ exports[`<Timeline /> renders the year view correctly 1`] = `
       />
       <RoomsGeomWrapper
         rooms={Array []}
-        timelineStartDate={"2018-09-30T23:00:00.000Z"}
+        timelineStartDate={"2018-09-30T21:00:00.000Z"}
         timelineViewType="year"
         tripDayWidth={0}
       />

--- a/src/components/modal/Modal.jsx
+++ b/src/components/modal/Modal.jsx
@@ -29,10 +29,15 @@ class Modal extends PureComponent {
 
   renderModalHeader = () => {
     const { title, closeModal, modalBar, params, closeDeleteCommentModal, requestId } = this.props;
-    let url = location.pathname;
-    if(requestId){
+    let url;
+    if (location.pathname.includes('/requests')) {
+      url = '/requests/';
+    } else {
+      url = location.pathname;
+    }
+    if (requestId) {
       let urlArr = url.split('/');
-      url = urlArr.slice(0, urlArr.length-1).join('/');
+      url = urlArr.slice(0, urlArr.length - 1).join('/');
     }
     return (
       <div className="modal-title-bar">
@@ -52,11 +57,18 @@ class Modal extends PureComponent {
           )
           :
           (
-            <Link to={url}>
-              <button type="button" onClick={closeDeleteCommentModal ? closeDeleteCommentModal : closeModal} className="modal-close">
-                <img alt="close" src={closeButton} />
-              </button>
-            </Link>
+            (url.includes('/requests')) ?
+              (
+                <Link to={url}>
+                  <button type="button" onClick={closeDeleteCommentModal ? closeDeleteCommentModal : closeModal} className="modal-close">
+                    <img alt="close" src={closeButton} />
+                  </button>
+                </Link>
+              ) : (
+                <button type="button" onClick={closeDeleteCommentModal ? closeDeleteCommentModal : closeModal} className="modal-close">
+                  <img alt="close" src={closeButton} />
+                </button>
+              )
           )
         }
       </div>


### PR DESCRIPTION
#### What does this PR do?
Fixes the bug of clicking several times to go back to the accommodation details page after clicking close modal icon without making any changes.

#### Description of Task to be completed?
Ensure back arrow in a guest house details is clicked once to go back to accommodation details.

#### How should this be manually tested?
- Clone the repo `https://github.com/andela/travel_tool_front.git`
- Checkout to the branch:
```bg-backward-arrow-guesthouse-details-161176677```
- Install dependancies:
```yarn install```
- Start the application:
```yarn start```
- Log in locally and navigate to manage page in `Residence menu`
- Click to a guest room and click `edit guest room`
- Close the modal without making any changes
- Click the back arrow `<-` button once

#### Any background context you want to provide?
You should have the user role of a Travel Administrator or Super Administrator to be able to see the `manage` page. To do that:
- Download `Postico` and connect to your travela database with relevant details: Db name, password, port, user
- Click `userRoles` table and set the `roleId` to that of a Travel Administrator(29187) or Super Administrator(10948) 

#### What are the relevant pivotal tracker stories?
[161176677](https://www.pivotaltracker.com/story/show/161176677)