### PR TITLE
#161888236 Accommodation selection field on request initiation form

### DIFF
--- a/src/components/Forms/NewDocumentForm/NewDocumentForm.scss
+++ b/src/components/Forms/NewDocumentForm/NewDocumentForm.scss
@@ -10,7 +10,7 @@
 }
 
 form fieldset:last-child .submit-area {
-  width: 91%;
+  width: 100%;
 }
 
 .document-input {

--- a/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/TravelDetailsItem.test.js
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/TravelDetailsItem.test.js
@@ -91,14 +91,14 @@ describe('Test Suite for <TravelDetailsItem />', () => {
     const newProps = {...props};
     newProps.selection = 'oneWay';
     const wrapper = setup(newProps);
-    expect(props.renderInput).toHaveBeenCalledTimes(72);
+    expect(props.renderInput).toHaveBeenCalledTimes(82);
   });
 
   it('should render properly if selection is return', () => {
     const newProps = {...props};
     newProps.selection = 'return';
     const wrapper = setup(newProps);
-    expect(props.renderInput).toHaveBeenCalledTimes(87);
+    expect(props.renderInput).toHaveBeenCalledTimes(97);
   });
 });
 

--- a/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/__snapshots__/TravelDetailsItem.test.js.snap
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/__snapshots__/TravelDetailsItem.test.js.snap
@@ -45,7 +45,21 @@ exports[`Test Suite for <TravelDetailsItem /> should match snapshot 1`] = `
           />
           <div
             className="travel-to"
-          />
+          >
+            <div>
+              <img
+                alt="icn"
+                src="/static/media/form_select_dropdown.d19986d7.svg"
+                style={
+                  Object {
+                    "position": "absolute",
+                    "right": "15px",
+                    "top": "43px",
+                  }
+                }
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Forms/NewRequestForm/NewRequestForm.jsx
+++ b/src/components/Forms/NewRequestForm/NewRequestForm.jsx
@@ -54,6 +54,15 @@ class NewRequestForm extends PureComponent {
     }
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { values, trips, selection } = this.state;
+    if ((prevState.values.gender !== values.gender) && selection !== 'oneWay') {
+      trips.map((trip, index) => {
+        this.handlePickBed(null, index, false);
+      });
+    }
+  }
+
   componentWillUnmount() {
     const { fetchUserRequests, fetchAvailableRoomsSuccess } = this.props;
     fetchUserRequests();
@@ -221,6 +230,10 @@ class NewRequestForm extends PureComponent {
         }),
         this.validate
       );
+      const { selection } = this.state;
+      if ( selection !== 'oneWay'){
+        this.handlePickBed(null, getId, false);
+      }
     });
   };
 

--- a/src/components/Forms/NewRequestForm/NewRequestForm.scss
+++ b/src/components/Forms/NewRequestForm/NewRequestForm.scss
@@ -90,9 +90,9 @@ form.new-request {
       background-color: #f8f8f8;
       margin: 7px 0px 20px 0px;
       color: gray;
+      width: 100%;
       &.multi {
         border-left: 10px solid #FFAF30;
-        width: 100%;
       }
     }
     .style-details {

--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
   <TimelineBar
     customStyle={
       Object {
-        "background": "hsl(164,40%,70%)",
+        "background": "hsl(189,38%,58%)",
       }
     }
     tripDayWidth={31}
@@ -31,7 +31,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       className="geom-trip geom-trip--inner"
       style={
         Object {
-          "background": "hsl(164,50%,50%)",
+          "background": "hsl(189,48%,38%)",
           "width": "100%",
         }
       }

--- a/src/views/Analytics/__tests__/__snapshots__/Analytics.test.js.snap
+++ b/src/views/Analytics/__tests__/__snapshots__/Analytics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Analytics /> should render the connected component correctly 1`] = `
+exports[`<Analytics /> should render the connected component without crashing 1`] = `
 <div
   className="analytics"
 >


### PR DESCRIPTION
#### What does this PR do?
- Disable the available rooms dropdown on the accommodation page by default.
- Enable available rooms dropdown once the gender, travel-to, departure and arrival date have been filled
- Clear available rooms dropdown once a user has changed their gender, travel-to, departure and arrival date
- The grey area on a one-way trip extends the form when the user selects One Way Trip

#### Description of Task to be completed?
- The dropdown should only be selectable when every other required field have been filled i.e it should be disabled
- A value of 5( digits) should not be displayed in the select box where there are no rooms available
- The grey area on a one-way trip should extend the form when the user selects One Way Trip
- The UI design on submission areas should line up with what is on [Invision](https://projects.invisionapp.com/d/main#/console/14861108/319652028/preview)

#### How should this be manually tested?
- Setting up the backend
     - Clone the repo - `git clone https://github.com/andela/travel_tool_back.git`
     - Enter into the project directory - `cd travel_tool_back`
     - checkout the branch git checkout `develop`
     - Install dependencies using `yarn install`
     - Rollback and run database migrations with `yarn db:rollmigrate`

- Setting up the frontend
   - Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
   - Enter into the project directory - `cd travel_tool_front`
   - Checkout to the branch `bg-fix-accomodation-selection-field-161888236` then run the app
   - login to the application
   - Visit the accommodation page and make a new travel request
   - Try entering the gender, travel-to, departure and return date using any combination
   - the available rooms dropdown does not get enabled until the minimum required fields have been filled.
   - The UI design on submission areas should line up with what is on [Invision](https://projects.invisionapp.com/d/main#/console/14861108/319652028/preview)
   - The grey area on a one-way trip should be extending the form when the user selects One Way Trip

#### Any background context you want to provide?
I'm using the text type input as the default rendered input on the page because it's easier to disable before the required fields receive values.

#### What are the relevant pivotal tracker stories?
[#161888236](https://www.pivotaltracker.com/story/show/161888236)
[#162167075](https://www.pivotaltracker.com/story/show/162167075)

#### Screenshots (if appropriate)
![available-rooms-video](https://user-images.githubusercontent.com/21138053/48948144-8865fd00-ef44-11e8-96fa-d24f284a15cd.gif)
