### PR TITLE
#161981260 Change multi-trip return date

### DIFF
--- a/src/components/Forms/FormsAPI/index.js
+++ b/src/components/Forms/FormsAPI/index.js
@@ -29,11 +29,15 @@ class InputRenderer {
   }
 
   renderInput = (name, type, customProps) => {
+    const selection = customProps && customProps.selection;
+    const labelKey = name.split('-')[0];
+    const fieldName = (labelKey.match('arrivalDate') && (selection && !selection.match('return')))
+      ? 'leavingDate' : labelKey;
     let inputProps = {
       name,
       type,
-      label: this.formMetadata.inputLabels[name.split('-')[0]].label,
-      labelNote: this.formMetadata.inputLabels[name.split('-')[0]].note,
+      label: this.formMetadata.inputLabels[fieldName].label,
+      labelNote: this.formMetadata.inputLabels[fieldName].note,
       autoComplete: 'off'
     };
     customProps ? inputProps['data-parentid'] = customProps.parentid : null;

--- a/src/components/Forms/FormsMetadata/NewRequestFormMetadata/inputLabels.js
+++ b/src/components/Forms/FormsMetadata/NewRequestFormMetadata/inputLabels.js
@@ -40,6 +40,10 @@ const inputLabels = {
     label: 'Return'
   },
 
+  leavingDate: {
+    label: 'Leaving'
+  },
+
   bed: {
     label: 'Available rooms'
   },

--- a/src/components/Forms/NewRequestForm/FormFieldsets/TravelDetailsItem.jsx
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/TravelDetailsItem.jsx
@@ -104,7 +104,8 @@ class TravelDetailsItem extends Component {
       itemId,
       values,
       renderInput,
-      customPropsForDeparture
+      customPropsForDeparture,
+      selection,
     } = this.props;
     return (
       <div className="others-width" role="presentation">
@@ -112,7 +113,8 @@ class TravelDetailsItem extends Component {
           ...customPropsForDeparture(values),
           parentid: itemId,
           handleDate: this.handleDate,
-          onChange: this.handleDate
+          onChange: this.handleDate,
+          selection
         })}
       </div>
     );
@@ -124,6 +126,7 @@ class TravelDetailsItem extends Component {
       values,
       renderInput,
       customPropsForArrival,
+      selection,
     } = this.props;
     return(
       <div className="others-width" role="presentation">
@@ -134,7 +137,8 @@ class TravelDetailsItem extends Component {
           ),
           parentid: itemId,
           handleDate: this.handleDate,
-          onChange: this.handleDate
+          onChange: this.handleDate,
+          selection
         })}
       </div>
     );

--- a/src/components/Forms/NewRequestForm/NewRequestForm.jsx
+++ b/src/components/Forms/NewRequestForm/NewRequestForm.jsx
@@ -121,6 +121,9 @@ class NewRequestForm extends PureComponent {
     const dateName = dateWrapperId.split('_')[0];
     const getId = dateName.split('-')[1];
     const dateStartsWithDeparture = dateName.startsWith('departure');
+    const dateStartsWithArrival = dateName.startsWith('arrival');
+
+
     if (trips[getId]) {
       if (dateStartsWithDeparture) {
         trips[getId].departureDate = dateFormat;
@@ -131,6 +134,26 @@ class NewRequestForm extends PureComponent {
       trips.push({
         [dateName.split('-')[0]]: dateFormat
       });
+    }
+
+    if (dateStartsWithArrival && selection === 'multi' ) {
+      const targetFieldId = Number(getId) + 1;
+      this.setState(
+        prevState => {
+          const { trips } = prevState;
+          const newTrips = [...trips];
+
+          if (targetFieldId < newTrips.length) { newTrips[targetFieldId].departureDate = dateFormat; }
+          return {
+            targetFieldId,
+            values: {
+              ...prevState.values,
+              [`departureDate-${targetFieldId}`]: date
+            },
+            trips: [...newTrips]
+          };
+        }
+      );
     }
 
     const onPickDate =
@@ -327,13 +350,19 @@ class NewRequestForm extends PureComponent {
     return this.setState(prevState => {
       const { parentIds, values, trips } = prevState;
       const addedTripStateValues = this.getDefaultTripStateValues(parentIds);
+      const nextDepartureField = `departureDate-${parentIds}`;
+      const lastArrivalValue = values[`arrivalDate-${parentIds - 1}`];
+      addedTripStateValues[nextDepartureField] = lastArrivalValue;
+      const newTripDepartureDate = lastArrivalValue && lastArrivalValue.format('YYYY-MM-DD');
+
       return {
         parentIds: parentIds + 1,
-        trips: trips.concat([{}]),
+        trips: trips.concat([{departureDate: newTripDepartureDate}]),
         values: { ...values, ...addedTripStateValues }
       };
     }, this.validate);
   }
+
   removeTrip = (i) => {
     const tripProps = ['origin', 'destination', 'arrivalDate', 'departureDate', 'bed'];
     this.setState((prevState) => {

--- a/src/components/RequestsModal/TripDetails/index.jsx
+++ b/src/components/RequestsModal/TripDetails/index.jsx
@@ -29,7 +29,7 @@ export default class TripDetails extends PureComponent {
       <div id="return-date">
         { tripType !== 'oneWay' ?
           (<TripDetail
-            label="Return date"
+            label={tripType === 'multi' ? 'Leaving' : 'Return date'}
             value={generateDynamicDate(tripDetails, returnDate)} />
           )  : ''
         }

--- a/src/components/TravelCheckList/travelSubmission.scss
+++ b/src/components/TravelCheckList/travelSubmission.scss
@@ -339,7 +339,6 @@
 
 .submission-progress__ {
     color: #3359DB;
-    border: 1px solid, blue;
     font-size: 11px;
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
#### What does this PR do?
This PR updates Return Date field on a multi-city trip request form

#### Description of Task to be completed?
- change the label from 'Return' to 'Leaving'
- autofill next trip departure date with the return date of preceding trip

#### How should this be manually tested?
- Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- Change into the project directory -` cd travel_tool_front`
- Pull and checkout into this branch - `ch-remove-multi-trips-return-date-161981260`
- Install project dependencies using `yarn install`
- Clone the [Travela backend](https://github.com/andela/travel_tool_back)
- Run database migrations using `yarn run db:rollmigrate`
- Check `.env.example` and set up your `.env` appropriately
- Start the Server and Frontend with `make start` and log into the application
- Create a new travel request
- On the new request form, for a multi city trip
  - The 'Return' label should be 'Leaving'
  -  Filling the leaving date should autofill the departure date of the next trip

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#161981260](https://www.pivotaltracker.com/story/show/161981260)

#### Screenshots (if appropriate)

<img width="1204" alt="screen shot 2018-11-22 at 11 48 25 am" src="https://user-images.githubusercontent.com/32720508/48898773-f2e84180-ee4d-11e8-9b50-7f98f7b749e0.png">

#### Questions:
N/A
