### PR TITLE
#162046982 Toggle travel readiness for outflow and inflow

### DIFF
--- a/src/components/AnalyticsReport/index.jsx
+++ b/src/components/AnalyticsReport/index.jsx
@@ -11,7 +11,8 @@ export default class AnalyticsReport extends Component {
   componentDidMount() {
     const { fetchDepartmentTrips, fetchReadiness } = this.props;
     fetchDepartmentTrips({filterBy: 'month', type: 'json'});
-    fetchReadiness({page: '1', limit: '6', type:'json'});
+    // fetch inflow travel flow on mount
+    fetchReadiness({page: '1', limit: '6', type:'json', travelFlow: 'inflow'});
   }
 
   getDepartmentTripsCSV = () => {

--- a/src/components/CalendarRange/__tests__/__snapshots__/CalendarRange.test.js.snap
+++ b/src/components/CalendarRange/__tests__/__snapshots__/CalendarRange.test.js.snap
@@ -199,7 +199,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
         >
           <input
             readOnly={true}
-            value="Nov 27, 2018"
+            value="Nov 28, 2018"
           />
         </span>
         <span
@@ -208,7 +208,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
         >
           <input
             readOnly={true}
-            value="Nov 27, 2018"
+            value="Nov 28, 2018"
           />
         </span>
       </div>
@@ -997,7 +997,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                     </span>
                   </button>
                   <button
-                    className="rdrDay rdrDayDisabled rdrDayWeekend rdrDayStartOfWeek"
+                    className="rdrDay rdrDayWeekend rdrDayStartOfWeek"
                     onBlur={[Function]}
                     onFocus={[Function]}
                     onKeyDown={[Function]}
@@ -1012,7 +1012,6 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                         "color": "#3d91ff",
                       }
                     }
-                    tabIndex={-1}
                     type="button"
                   >
                     <span

--- a/src/components/DashboardHeader/__tests__/__snapshots__/index.test.js.snap
+++ b/src/components/DashboardHeader/__tests__/__snapshots__/index.test.js.snap
@@ -247,7 +247,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
             >
               <input
                 readOnly={true}
-                value="Nov 27, 2018"
+                value="Nov 28, 2018"
               />
             </span>
             <span
@@ -256,7 +256,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
             >
               <input
                 readOnly={true}
-                value="Nov 27, 2018"
+                value="Nov 28, 2018"
               />
             </span>
           </div>
@@ -1045,7 +1045,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                         </span>
                       </button>
                       <button
-                        className="rdrDay rdrDayDisabled rdrDayWeekend rdrDayStartOfWeek"
+                        className="rdrDay rdrDayWeekend rdrDayStartOfWeek"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onKeyDown={[Function]}
@@ -1060,7 +1060,6 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                             "color": "#3d91ff",
                           }
                         }
-                        tabIndex={-1}
                         type="button"
                       >
                         <span

--- a/src/components/Forms/NewAccommodationForm/__tests__/__snapshots__/NewAccommodation.tests.js.snap
+++ b/src/components/Forms/NewAccommodationForm/__tests__/__snapshots__/NewAccommodation.tests.js.snap
@@ -230,7 +230,7 @@ exports[`<NewAccommodation /> renders correctly 1`] = `
               className="room"
             >
               <div
-                className="form-input  "
+                className="form-input add_room_type "
               >
                 <label
                   htmlFor="roomType-0"
@@ -261,7 +261,7 @@ exports[`<NewAccommodation /> renders correctly 1`] = `
                         "Non-Ensuite",
                       ]
                     }
-                    className="input select  "
+                    className="input select  add_room_type"
                     data-parentid={0}
                     error=""
                     handleDropDown={[Function]}

--- a/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/__snapshots__/TravelDetails.test.js.snap
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/__snapshots__/TravelDetails.test.js.snap
@@ -202,9 +202,9 @@ exports[`<TravelDetails /> should match snapshot 1`] = `
       selection="multi"
       values={
         Object {
-          "arrivalDate-1": "2019-10-29T23:00:00.000Z",
+          "arrivalDate-1": "2019-10-29T21:00:00.000Z",
           "bed-1": 1,
-          "departureDate-1": "2019-10-19T23:00:00.000Z",
+          "departureDate-1": "2019-10-19T21:00:00.000Z",
           "destination-1": "Lagos",
           "gender": "Male",
         }
@@ -213,8 +213,6 @@ exports[`<TravelDetails /> should match snapshot 1`] = `
   </div>
   <div
     className="add-multi-trip-area"
-    onClick={[Function]}
-    onKeyPress={[Function]}
     role="button"
     tabIndex="0"
   >

--- a/src/components/RequestsModal/CommentBox/__tests__/__snapshots__/RequestApproval.test.js.snap
+++ b/src/components/RequestsModal/CommentBox/__tests__/__snapshots__/RequestApproval.test.js.snap
@@ -22,7 +22,7 @@ exports[`RequestApproval component should match snapshot 1`] = `
     <span
       className="modal__hours-status"
     >
-      a few seconds ago
+      a minute ago
     </span>
   </span>
 </div>

--- a/src/components/RequestsModal/TripDetails/__tests__/__snapshots__/TripDetails.test.jsx.snap
+++ b/src/components/RequestsModal/TripDetails/__tests__/__snapshots__/TripDetails.test.jsx.snap
@@ -66,7 +66,7 @@ exports[`<TripDetails /> should render correctly 1`] = `
       <div
         className="modal__trip-detail-text"
       >
-        27 Nov 2018
+        28 Nov 2018
       </div>
     </div>
   </div>

--- a/src/components/RequestsModal/__tests__/__snapshots__/RequestsModal.test.js.snap
+++ b/src/components/RequestsModal/__tests__/__snapshots__/RequestsModal.test.js.snap
@@ -25,7 +25,7 @@ exports[` 1`] = `
       Date submitted: 
     </span>
     <b>
-      27 Nov 2018
+      28 Nov 2018
     </b>
   </span>
 </div>
@@ -56,7 +56,7 @@ exports[`Render RequestsModal component Connected RequestDetailsModal component 
       Date submitted: 
     </span>
     <b>
-      27 Nov 2018
+      28 Nov 2018
     </b>
   </span>
 </div>

--- a/src/components/Timeline/RoomsGeomWrapper/BedGeomWrapper/__tests__/__snapshots__/BedGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/BedGeomWrapper/__tests__/__snapshots__/BedGeomWrapper.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<BedGeomWrapper /> renders properly 1`] = `
 >
   <TripGeometry
     key="trip-id-1"
-    timelineStartDate={"2018-10-31T23:00:00.000Z"}
+    timelineStartDate={"2018-10-31T21:00:00.000Z"}
     timelineViewType="month"
     trip={
       Object {

--- a/src/components/Timeline/RoomsGeomWrapper/RoomGeomWrapper/__tests__/__snapshots__/RoomGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/RoomGeomWrapper/__tests__/__snapshots__/RoomGeomWrapper.test.jsx.snap
@@ -42,7 +42,7 @@ exports[`<RoomGeomWrapper /> renders properly 1`] = `
     </TimelineBarWrapper>
   </div>
   <BedGeomWrapper
-    timelineStartDate={"2018-10-31T23:00:00.000Z"}
+    timelineStartDate={"2018-10-31T21:00:00.000Z"}
     timelineViewType="month"
     tripDayWidth={31}
   />

--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
@@ -8,14 +8,14 @@ exports[`<TripGeometry /> renders correctly 1`] = `
     Object {
       "length": 7,
       "stayPercentage": "100%",
-      "tripTimelineOffsetLeft": -10230,
+      "tripTimelineOffsetLeft": -10261,
     }
   }
 >
   <TimelineBar
     customStyle={
       Object {
-        "background": "hsl(301,68%,71%)",
+        "background": "hsl(124,69%,56%)",
       }
     }
     tripDayWidth={31}
@@ -23,7 +23,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       Object {
         "length": 7,
         "stayPercentage": "100%",
-        "tripTimelineOffsetLeft": -10230,
+        "tripTimelineOffsetLeft": -10261,
       }
     }
   >
@@ -31,7 +31,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       className="geom-trip geom-trip--inner"
       style={
         Object {
-          "background": "hsl(301,78%,51%)",
+          "background": "hsl(124,79%,36%)",
           "width": "100%",
         }
       }

--- a/src/components/Timeline/RoomsGeomWrapper/__tests__/__snapshots__/RoomsGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/__tests__/__snapshots__/RoomsGeomWrapper.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`<RoomsGeomWrapper /> renders properly 1`] = `
     }
     key="room-id-1"
     status={false}
-    timelineStartDate={"2018-10-31T23:00:00.000Z"}
+    timelineStartDate={"2018-10-31T21:00:00.000Z"}
     timelineViewType="month"
     tripDayWidth={31}
   />

--- a/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
+++ b/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
@@ -165,12 +165,12 @@ exports[`<Timeline /> renders correctly 1`] = `
         key="25"
       />
       <div
-        className="timeline__segment current month-view"
+        className="timeline__segment  month-view"
         data-segment-label="27"
         key="26"
       />
       <div
-        className="timeline__segment  month-view"
+        className="timeline__segment current month-view"
         data-segment-label="28"
         key="27"
       />
@@ -187,7 +187,7 @@ exports[`<Timeline /> renders correctly 1`] = `
       <RoomsGeomWrapper
         handleChangeRoomModal={[Function]}
         rooms={Array []}
-        timelineStartDate={"2018-10-31T23:00:00.000Z"}
+        timelineStartDate={"2018-10-31T21:00:00.000Z"}
         timelineViewType="month"
         tripDayWidth={0}
       />
@@ -293,7 +293,7 @@ exports[`<Timeline /> renders the weekly view correctly 1`] = `
       <RoomsGeomWrapper
         handleChangeRoomModal={[Function]}
         rooms={Array []}
-        timelineStartDate={"2018-10-31T23:00:00.000Z"}
+        timelineStartDate={"2018-10-31T21:00:00.000Z"}
         timelineViewType="week"
         tripDayWidth={0}
       />
@@ -424,7 +424,7 @@ exports[`<Timeline /> renders the year view correctly 1`] = `
       <RoomsGeomWrapper
         handleChangeRoomModal={[Function]}
         rooms={Array []}
-        timelineStartDate={"2018-10-31T23:00:00.000Z"}
+        timelineStartDate={"2018-10-31T21:00:00.000Z"}
         timelineViewType="year"
         tripDayWidth={0}
       />

--- a/src/components/TravelReadiness/TravelReadiness.scss
+++ b/src/components/TravelReadiness/TravelReadiness.scss
@@ -1,0 +1,17 @@
+.travel-readiness-toggle-button-0, .travel-readiness-toggle-button-1 {
+    border: solid;
+    box-sizing: border-box;
+    height: 27px;
+    width: 87px;
+    text-align: center;
+    cursor: pointer;
+    border: 1px solid #E4E4E4;
+    background-color: #FFFFFF;
+    outline: none;
+    align-items: center;
+    color: #4F4F4F !important;
+}
+#active-travel-flow-button {
+    background-color: #3359DB;
+    color: white !important;
+}

--- a/src/components/TravelReadiness/__tests__/__snapshots__/travelReadiness.test.js.snap
+++ b/src/components/TravelReadiness/__tests__/__snapshots__/travelReadiness.test.js.snap
@@ -9,12 +9,28 @@ exports[`Test suite for Travel Readiness Component should match the snapshot 1`]
     }
   }
 >
+  <p>
+    Travel Readiness
+  </p>
   <div
     className="analyticsReport__row analyticsReport__header"
   >
-    <p>
-      Travel Readiness
-    </p>
+    <button
+      className="travel-readiness-toggle-button-0"
+      id="active-travel-flow-button"
+      onClick={[Function]}
+      type="button"
+    >
+      Inflow
+    </button>
+    <button
+      className="travel-readiness-toggle-button-1"
+      id={null}
+      onClick={[Function]}
+      type="button"
+    >
+      Ouflow
+    </button>
     <Button
       altText=""
       badge={null}

--- a/src/components/TravelReadiness/__tests__/travelReadiness.test.js
+++ b/src/components/TravelReadiness/__tests__/travelReadiness.test.js
@@ -33,13 +33,26 @@ const setup = (props) => {
 };
 describe('Test suite for Travel Readiness Component', () => {
   let wrapper;
-  beforeAll(() => {
+  beforeEach(() => {
     wrapper = setup();
   });
 
-  it('should render the component properly', () => {
+  it('should render the component properly when inflow or during first render', () => {
     const analyticsReport = wrapper.find('.analyticsReport__row');
+    const getTravelFlowSpy = jest.spyOn(wrapper.instance(), 'getTravelFlow');
+    wrapper.find('.travel-readiness-toggle-button-0').simulate('click');
+    expect(getTravelFlowSpy).toHaveBeenCalledTimes(1);
     expect(wrapper.length).toBe(1);
+    expect(wrapper.find('#active-travel-flow-button').length).toBe(1);
+    expect(analyticsReport.length).toBe(3);
+  });
+  it('should render component properly when outflow travel readiness is requested', () => {
+    const analyticsReport = wrapper.find('.analyticsReport__row');
+    const getTravelFlowSpy = jest.spyOn(wrapper.instance(), 'getTravelFlow');
+    wrapper.find('.travel-readiness-toggle-button-1').simulate('click');
+    expect(getTravelFlowSpy).toHaveBeenCalledTimes(1);
+    expect(wrapper.length).toBe(1);
+    expect(wrapper.find('#active-travel-flow-button').length).toBe(1);
     expect(analyticsReport.length).toBe(3);
   });
 

--- a/src/components/TravelReadiness/index.jsx
+++ b/src/components/TravelReadiness/index.jsx
@@ -5,10 +5,12 @@ import generateDynamicDate from '../../helper/generateDynamicDate';
 import download from '../../images/icons/save_alt_24px.svg';
 import Button from '../buttons/Buttons';
 import TravelReadinessPlaceholder from '../Placeholders/TravelReadinessPlaceholder';
+import './TravelReadiness.scss';
 
 class TravelReadiness extends Component {
   constructor(props) {
     super(props);
+    this.state = {};
   }
   renderReadinessDetails = (item, index) => {
     return (
@@ -25,27 +27,59 @@ class TravelReadiness extends Component {
       </div>
     );
   }
+  
   getReadinessCSV = () => {
     const { exportReadiness } = this.props;
-    exportReadiness({ type: 'file', });
+    const { travelFlow } = this.state; 
+    exportReadiness({ type: 'file', travelFlow: travelFlow});
+  }
+  
+  getTravelFlow = travelArgument => {
+    const { fetchReadiness } = this.props;
+    this.setState({
+      travelFlow: travelArgument
+    });
+    fetchReadiness({page: '1', limit: '6', type:'json', travelFlow: travelArgument});
+  }
 
+  travelFlowButton = () => {
+    const { travelFlow } = this.state;
+    const travelButton = (
+      <Fragment>
+        <button 
+          className="travel-readiness-toggle-button-0" type="button" 
+          id={travelFlow !== 'outflow' ? 'active-travel-flow-button' : null} 
+          onClick={() => this.getTravelFlow('inflow')}>
+        Inflow
+        </button>
+        <button 
+          className="travel-readiness-toggle-button-1" type="button"
+          id={travelFlow === 'outflow' ? 'active-travel-flow-button' : null}
+          onClick={() => this.getTravelFlow('outflow')}>
+        Ouflow
+        </button>
+      </Fragment>
+    );
+    return travelButton;
   }
 
   render() {
-    const { readiness, renderNotFound, renderButton, renderSpinner } = this.props;
+    const { readiness, renderNotFound, renderButton } = this.props;
     const { isLoading} = readiness;
+    const { travelFlow } = this.state;
     return (
       <div className="analyticsReport__card" style={{marginRight: '30px'}}>
-        { isLoading ?
+        {isLoading ? 
           <TravelReadinessPlaceholder /> : (
             <Fragment>
+              <p>Travel Readiness</p>
               <div className="analyticsReport__row analyticsReport__header">
-                <p>Travel Readiness</p>
+                {this.travelFlowButton()}
                 <Button
                   buttonClass="analyticsReport__export-button"
-                  reverseText buttonId="btnExportReadinessCSV"
-                  text="Export" imageSrc={download}
-                  onClick={this.getReadinessCSV} />
+                  reverseText buttonId="btnExportReadinessCSV" 
+                  text="Export" imageSrc={download} 
+                  onClick={travelFlow === 'outflow' ? () => this.getReadinessCSV('outflow') : () => this.getReadinessCSV('inflow')} />
               </div>
               <div className="analyticsReport__row analyticsReport__report-header">
                 <div>
@@ -60,9 +94,7 @@ class TravelReadiness extends Component {
               </div>
               {readiness.readiness && readiness.readiness.length > 0 && !readiness.isLoading &&
             readiness.readiness.map((item, index) => this.renderReadinessDetails(item, index))}
-              {readiness.readiness && !readiness.readiness.length &&
-            renderNotFound()
-              }
+              {readiness.readiness && !readiness.readiness.length && renderNotFound()}
             </Fragment>
           )}
       </div>
@@ -72,10 +104,9 @@ class TravelReadiness extends Component {
 TravelReadiness.propTypes = {
   readiness: PropTypes.object.isRequired,
   exportReadiness:PropTypes.func.isRequired,
+  fetchReadiness: PropTypes.func.isRequired,
   renderButton: PropTypes.func.isRequired,
-  renderNotFound: PropTypes.func.isRequired,
-  renderSpinner: PropTypes.func.isRequired
+  renderNotFound: PropTypes.func.isRequired
 };
 
 export default TravelReadiness;
-

--- a/src/redux/middleware/travelReadinessSaga.js
+++ b/src/redux/middleware/travelReadinessSaga.js
@@ -34,19 +34,3 @@ export function* exportReadinessSaga(action){
 export function* watchExportReadiness(){
   yield takeEvery(EXPORT_TRAVEL_READINESS, exportReadinessSaga);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/services/ReadinessAPI.js
+++ b/src/services/ReadinessAPI.js
@@ -7,11 +7,16 @@ const query = {
 
 class ReadinessAPI {
   static getTravelReadiness(query) {
-    return axios.get(`${baseUrl}/analytics/readiness?page=${query.page}&limit=${query.limit}&type=${query.type}`);
+    return axios.get(
+      `${baseUrl}/analytics/readiness?page=${query.page}&limit=${query.limit}&type=${query.type}&travelFlow=${query.travelFlow}`
+    );
   }
 
   static exportTravelReadiness(query) {
-    return axios.get(`${baseUrl}/analytics/readiness?type=${query.type}`, {responseType: 'blob'});
+    return axios.get(
+      `${baseUrl}/analytics/readiness?type=${query.type}&travelFlow=${query.travelFlow}`,
+      {responseType: 'blob'}
+    );
   }
 }
 

--- a/src/services/__tests__/ReadinessAPI.test.js
+++ b/src/services/__tests__/ReadinessAPI.test.js
@@ -17,12 +17,13 @@ describe('Readiness API', () => {
     const query = {
       page: '1',
       limit: '5',
-      type: 'json'
+      type: 'json',
+      travelFlow: 'inflow'
     };
     moxios.stubRequest(
       `${baseUrl}/analytics/readiness?page=${query.page}&limit=${
         query.limit
-      }&type=${query.type}`,
+      }&type=${query.type}&travelFlow=${query.travelFlow}`,
       {
         status: 200,
         response: fetchReadinessResponse
@@ -32,23 +33,24 @@ describe('Readiness API', () => {
     expect(moxios.requests.mostRecent().url).toEqual(
       `${baseUrl}/analytics/readiness?page=${query.page}&limit=${
         query.limit
-      }&type=${query.type}`
+      }&type=${query.type}&travelFlow=${query.travelFlow}`
     );
     expect(response.data).toEqual(fetchReadinessResponse);
   });
   it('should make a get request to export travel readiness', async () => {
     const query = {
-      type: 'file'
+      type: 'file',
+      travelFlow: 'inflow'
     };
     moxios.stubRequest(
-      `${baseUrl}/analytics/readiness?type=${query.type}`,
+      `${baseUrl}/analytics/readiness?type=${query.type}&travelFlow=${query.travelFlow}`,
       {
         status: 200,
       }
     );
     const response = await ReadinessAPI.exportTravelReadiness(query);
     expect(moxios.requests.mostRecent().url).toEqual(
-      `${baseUrl}/analytics/readiness?type=${query.type}`
+      `${baseUrl}/analytics/readiness?type=${query.type}&travelFlow=${query.travelFlow}`
     );
     expect(response.status).toEqual(200);
   });

--- a/src/views/Requests/__tests__/__snapshots__/Requests.test.js.snap
+++ b/src/views/Requests/__tests__/__snapshots__/Requests.test.js.snap
@@ -254,6 +254,7 @@ exports[`<Requests> renders as expected 1`] = `
       fetchSubmission={[Function]}
       fetchUserRequests={[Function]}
       fileUploads={Object {}}
+      handleCloseSubmissionModal={[Function]}
       history={
         Object {
           "push": [Function],
@@ -446,7 +447,6 @@ exports[`<Requests> renders as expected 1`] = `
         }
       }
       type="requests"
-      uploadTripSubmissions={[Function]}
     />
   </div>
   <div


### PR DESCRIPTION
#### What does this PR do?
-Enable Travel admin should view travel readiness of potential travelers to their center and out of their centers

#### Description of Task to be completed?
- Admin is able to toggle between travel readiness of inflow and outflow
- Admin is able to download the CSV for inflow and outflow data

#### How should this be manually tested?

- Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- Change directory - `cd travel_tool_front`
- Checkout to current branch - `git checkout ft-toggle-travel-readiness-card-162046982`
- Run application - `yarn start`
- Login into the application
- Start the backend of the application on [this PR](https://github.com/andela/travel_tool_back/pull/177)
- Assign yourself the role of admin in the database
- Refresh the frontend
- Click on dashboard 
- Check travel readiness and perform inflow and outflow including downloading the CSV files

#### Any background context you want to provide?
- You need to assign yourself the role of Travel Admin or SuperAdmin to access the dashboard

#### What are the relevant pivotal tracker stories?
[Delivers 162046982](https://www.pivotaltracker.com/story/show/162046982)

#### Screenshots (if appropriate)

<img width="563" alt="screen shot 2018-11-23 at 16 30 54" src="https://user-images.githubusercontent.com/32410518/48946200-fbb84080-ef3d-11e8-9136-90795f149d8b.png">
<img width="551" alt="screen shot 2018-11-23 at 16 31 13" src="https://user-images.githubusercontent.com/32410518/48946205-01ae2180-ef3e-11e8-89ae-6b6d672c4402.png">

#### Questions:
None
