### PR TITLE
#162154742 Fix Upload errors for files with filenames starting with digits

### DIFF
--- a/src/components/Forms/NewDocumentForm/index.jsx
+++ b/src/components/Forms/NewDocumentForm/index.jsx
@@ -21,8 +21,28 @@ class NewDocumentForm extends PureComponent {
       hasBlankFields: true,
     };
     this.state = {...this.defaultState};
-    this.validate = getDefaultBlanksValidatorFor(this);
   }
+
+  validate = (field = 'name') => {
+    let { values, errors } = this.state;
+    [errors, values] = [{ ...errors }, { ...values }];
+    let hasBlankFields = false;
+    !values[field]
+      ? (errors[field] = 'This field is required')
+      : (errors[field] = '');
+
+    hasBlankFields = Object.keys(values).some(key => !values[key]);
+    const fileNameRegex = /(^[A-Za-z])(.+)$/;
+    if(values[field] && !fileNameRegex.test(values[field])) {
+      errors[field] = 'File name must start with an alphabet';
+      // set to true to disable 'save' button
+      hasBlankFields = true;
+    }
+    this.setState(prevState => {
+      return { ...prevState, errors, hasBlankFields };
+    });
+    return !hasBlankFields;
+  };
 
   handleCancel = () => {
     const { closeModal } = this.props;
@@ -43,8 +63,8 @@ class NewDocumentForm extends PureComponent {
     }
     fileReader.onload = () => {
       this.setState(
-        prevState => 
-          ({ values: 
+        prevState =>
+          ({ values:
             {
               ...prevState.values,
               name: (file.name).replace(/\.[^/.]+$/, ''),


### PR DESCRIPTION
#### What does this PR do?
Show a validation message for files with filenames starting with digits and disable 'save' button.

#### Description of Task to be completed?
- prevent filename from starting with digits
- show error message on the input field

#### How should this be manually tested?
- Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- checkout this branch - `git checkout bg-fix-document-filename-162154742`
- run `yarn start`
- Clone the backend repo - `git clone https://github.com/andela/travel_tool_back.git`
- run `yarn db:rollmigrate` on the backend directory and run `yarn start:dev`
- go to `http://localhost:3000/documents`
- add a new document and set the name beginning with a digit

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162154742](https://www.pivotaltracker.com/story/show/162154742)

#### Screenshots (if appropriate)
![2018-11-23 07 28 05](https://user-images.githubusercontent.com/25967737/48930537-76a73a00-eef1-11e8-825e-b5704284cfdf.gif)

#### Questions:
None