### PR TITLE
#162046605 Link pending requests card to my verifications page

### DIFF
--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
   <TimelineBar
     customStyle={
       Object {
-        "background": "hsl(189,38%,58%)",
+        "background": "hsl(196,64%,52%)",
       }
     }
     tripDayWidth={31}
@@ -31,7 +31,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       className="geom-trip geom-trip--inner"
       style={
         Object {
-          "background": "hsl(189,48%,38%)",
+          "background": "hsl(196,74%,32%)",
           "width": "100%",
         }
       }

--- a/src/views/Analytics/__tests__/Analytics.test.js
+++ b/src/views/Analytics/__tests__/Analytics.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 
 import ConnectedAnalytics, {mapStateToProps, Analytics} from '..';
@@ -42,12 +43,20 @@ beforeEach(() => {
 
 describe('<Analytics />', () => {
   it('calls ComponentDidMount', () => {
-    wrapper = shallow(<Analytics {...props} />);
+    wrapper = shallow(
+      <MemoryRouter>
+        <Analytics {...props} />
+      </MemoryRouter>
+    ).dive().dive();
     expect(props.fetchAnalytics).toHaveBeenCalled();
   });
 
   it('call componentWillReceiveProps', () => {
-    wrapper = shallow(<Analytics {...props} />);
+    wrapper = shallow(
+      <MemoryRouter>
+        <Analytics {...props} />
+      </MemoryRouter>
+    ).dive().dive();
     wrapper.setProps({
       context: {
         state: {
@@ -65,7 +74,9 @@ describe('<Analytics />', () => {
   it('should render the connected component without crashing', () => {
     wrapper = mount(
       <Provider store={store}>
-        <ConnectedAnalytics {...props} />
+        <MemoryRouter>
+          <ConnectedAnalytics {...props} />
+        </MemoryRouter>
       </Provider>
     );
 

--- a/src/views/Analytics/__tests__/__snapshots__/Analytics.test.js.snap
+++ b/src/views/Analytics/__tests__/__snapshots__/Analytics.test.js.snap
@@ -40,25 +40,30 @@ exports[`<Analytics /> should render the connected component without crashing 1`
     >
       Total Number of Pending Requests
     </h3>
-    <div
-      className="analytics-card__stats "
+    <a
+      href="/requests/my-verifications"
+      onClick={[Function]}
     >
       <div
-        className="analytics-card__icon"
+        className="analytics-card__stats "
       >
-        <img
-          alt=""
-          src="pending_icon.svg"
-        />
+        <div
+          className="analytics-card__icon"
+        >
+          <img
+            alt=""
+            src="pending_icon.svg"
+          />
+        </div>
+        <div
+          className="analytics-card__stat"
+        >
+          <h4>
+            0
+          </h4>
+        </div>
       </div>
-      <div
-        className="analytics-card__stat"
-      >
-        <h4>
-          0
-        </h4>
-      </div>
-    </div>
+    </a>
   </div>
   <div
     className="analytics-card"

--- a/src/views/Analytics/index.jsx
+++ b/src/views/Analytics/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react';
+import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -32,9 +33,15 @@ export class Analytics extends Component {
     }
   }
 
-  renderCards = (title, props) => (
+  renderCards = (title, props, link) => (
     <AnalyticsCard title={title}>
-      {props.chart ? <PieChartAnalytics {...props} /> : <StatsAnalytics {...props} />}
+      {
+        link ? (
+          <Link to={link}><StatsAnalytics {...props} /></Link>
+        ) : (
+          props.chart ? <PieChartAnalytics {...props} /> : <StatsAnalytics {...props} />
+        )
+      }
     </AnalyticsCard>
   );
 
@@ -69,7 +76,7 @@ export class Analytics extends Component {
         ) : (
           <div className="analytics">
             {this.renderCards('Total No. of Travel Requests', {stats: totalRequests, icon: flightIcon} )}
-            {this.renderCards('Total Number of Pending Requests', {stats: pendingRequests, icon: pendingIcon})}
+            {this.renderCards('Total Number of Pending Requests', {stats: pendingRequests, icon: pendingIcon}, '/requests/my-verifications')}
             {this.renderCards('Average Travel Duration', {data: (analytics.success ? travelDurationBreakdown.durations : []), chart: true})}
             {this.renderCards(`No. of People visiting ${context.state.city} Center`,
               {stats: peopleVisiting, icon: flightLand, color: 'green'}


### PR DESCRIPTION
#### What does this PR do?
View a clickable card for 'Total number of pending requests'

#### Description of Task to be completed?
- Link pending requests card to my verifications 

#### How should this be manually tested?
- Clone the repo `https://github.com/andela/travel_tool_front.git`
- Checkout to the branch:
`ft-pending-requests-analytics-162046605`
- Install dependencies:
```yarn install```
`yarn test`
- All the tests should be passing
- Start the application:
```yarn start```

- Login to the application
- Navigate to the dashboard page on the sidebar
- The pending requests card should be clickable and takes you to `/requests/my-verifications` page

#### Any background context you want to provide?
2. You should have the user role of a Travel Administrator or Super Administrator to be able to see the `manage` page. To do that:
  - Download `Postico` and connect to your travela database with relevant details: Db name, password, port, user
  - Click `userRoles` table and set the `roleId` to that of a Travel Administrator(29187) or Super[]Administrator(10948) 
- ##### currently `my-verifications page` doesn't exists so it will take you to and empty page

#### What are the relevant pivotal tracker stories?
[#162046605](https://www.pivotaltracker.com/story/show/162046605)

