### PR TITLE
#162181076 Fix spacing of dropdown input

### DIFF
--- a/src/components/Forms/NewAccommodationForm/FormFieldsets/AccommodationDetails.jsx
+++ b/src/components/Forms/NewAccommodationForm/FormFieldsets/AccommodationDetails.jsx
@@ -49,7 +49,8 @@ class AccommodationDetails extends Component {
             <div className="room">
               {renderInput(`roomType-${i}`, 'dropdown-select', {
                 parentid: i,
-                handleDropDown
+                handleDropDown,
+                className: 'add_room_type'
               })}
             </div>
             <div className="room remove" onChange={handleInputChange}>

--- a/src/components/Forms/ProfileForm/ProfileForm.scss
+++ b/src/components/Forms/ProfileForm/ProfileForm.scss
@@ -38,10 +38,6 @@ form .form-input .profile_dropdown .select-menu {
   top: 30px;
 }
 
-form .form-input .request_dropdown .select-menu{
-  top: 26px
-}
-
 .spaces .request_dropdown .select-menu{
   top: 35px
 }
@@ -49,7 +45,6 @@ form .form-input .request_dropdown .select-menu{
 form .form-input .select-menu{
   position: absolute;
   left: -0.05px;
-  top: 40px;
   width: calc(100% + -1px);
   color: #4F4F4F;
   font-family: 'DIN Pro';

--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/TripDetails/TripDetails.scss
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/TripDetails/TripDetails.scss
@@ -98,9 +98,9 @@
     .trip-booking-details {
       transform-origin: bottom;
       &.details-visible {
-        transform: translateY(-110%) scaleY(1);
+        transform: translateY(-10%) scaleY(1);
         &.translateX {
-          transform: translateY(-110%) scaleY(1) translateX(-90%);
+          transform: translateY(-10%) scaleY(1) translateX(-90%);
         }
       }
       &.details-hidden {


### PR DESCRIPTION
#### What does this PR do?
Fixes the spacing above the dropdown so that it matches the mockup.


#### Description of Task to be completed?
There is some spacing in the drop down not needed in the application. It is expected that the unnecessary spacing does not exist on drop-down options in forms.

#### How should this be manually tested?
- Clone the repo - git clone https://github.com/andela/travel_tool_front.git
- Change into the project directory
- Run ```git checkout bg-fix-dropdown-input-162181076```
- Then Run ```yarn start```
- Ensure you set your role to `Travel Admin`
- Navigate to `Residence` and click `Manage`. Click `Add Guesthouse`
- Click `RoomType` dropdown

#### Any background context you want to provide?


#### What are the relevant pivotal tracker stories?
[162181076 ](https://www.pivotaltracker.com/story/show/162181076)

#### Screenshots (if appropriate)
##### before
![image](https://user-images.githubusercontent.com/30747298/49011485-a0798e80-f187-11e8-8098-6dcf6c698c3b.png)

#### after
![image](https://user-images.githubusercontent.com/30747298/49011498-a96a6000-f187-11e8-885f-170d69e42e38.png)



#### Questions: