### PR TITLE
#162192899  Auto-fill multicity request origin field 

### DIFF
--- a/src/components/Forms/NewRequestForm/FormFieldsets/TravelDetails.jsx
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/TravelDetails.jsx
@@ -64,7 +64,7 @@ class TravelDetailsFieldset extends Component {
   renderAddAnotherBtn = () => {
     const { addNewTrip } = this.props;
     return (
-      <div className="add-multi-trip-area" onClick={addNewTrip} onKeyPress={addNewTrip} role="button" tabIndex="0">
+      <div className="add-multi-trip-area" role="button" tabIndex="0">
         <button type="button" className="another-trip" onClick={addNewTrip}>
           <img src={addMultipleCityBtn} alt="clicked" className="addsvg" />
           Add another trip

--- a/src/components/Forms/NewRequestForm/NewRequestForm.jsx
+++ b/src/components/Forms/NewRequestForm/NewRequestForm.jsx
@@ -234,6 +234,26 @@ class NewRequestForm extends PureComponent {
       if ( selection !== 'oneWay'){
         this.handlePickBed(null, getId, false);
       }
+
+      if (name.startsWith('destination') && selection === 'multi' ) {
+        const targetFieldId = Number(getId) + 1;
+        this.setState(
+          prevState => {
+            const { trips } = prevState;
+            const newTrips = [...trips];
+
+            if (targetFieldId < newTrips.length) { newTrips[targetFieldId].origin = places; }
+            return {
+              targetFieldId,
+              values: {
+                ...prevState.values,
+                [`origin-${targetFieldId}`]: places
+              },
+              trips: [...newTrips]
+            };
+          }
+        );
+      }
     });
   };
 
@@ -365,12 +385,18 @@ class NewRequestForm extends PureComponent {
       const addedTripStateValues = this.getDefaultTripStateValues(parentIds);
       const nextDepartureField = `departureDate-${parentIds}`;
       const lastArrivalValue = values[`arrivalDate-${parentIds - 1}`];
+      const nextOriginField = `origin-${parentIds}`;
+      const lastDepartureLocation = values[`destination-${parentIds - 1}`];
       addedTripStateValues[nextDepartureField] = lastArrivalValue;
+      addedTripStateValues[nextOriginField] = lastDepartureLocation;
       const newTripDepartureDate = lastArrivalValue && lastArrivalValue.format('YYYY-MM-DD');
 
       return {
         parentIds: parentIds + 1,
-        trips: trips.concat([{departureDate: newTripDepartureDate}]),
+        trips: trips.concat([{
+          departureDate: newTripDepartureDate,
+          origin: lastDepartureLocation
+        }]),
         values: { ...values, ...addedTripStateValues }
       };
     }, this.validate);

--- a/src/components/Forms/NewRequestForm/NewRequestForm.scss
+++ b/src/components/Forms/NewRequestForm/NewRequestForm.scss
@@ -162,6 +162,7 @@ h1 {
   border-style: dashed;
   border-radius: 2px;
   background-color: #FFFFFF;
+  outline: none;
   @media (max-width: 1405px) {
     width: 1000px;
   }


### PR DESCRIPTION
#### What does this PR do?
This PR enables the origin field in a multicity trip request to be prefilled with the destination of the preceeding trip

#### Description of Task to be completed?
- autofill origin field with the destination of preceding trip in a multicity trip request.

#### How should this be manually tested?
- Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- Change into the project directory -` cd travel_tool_front`
- Pull and checkout into this branch - `ch-autofill-multicity-origin-date-162045984`
- Install project dependencies using `yarn install`
- Clone the [Travela backend](https://github.com/andela/travel_tool_back)
- Run database migrations using `yarn run db:rollmigrate`
- Check `.env.example` and set up your `.env` appropriately
- Start the Server and Frontend with `make start` and log into the application
- Create a new travel request
- On the new request form, for a multi city trip
  -  Filling the destination of a trip should autofill the origin field of the next trip

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162192899](https://www.pivotaltracker.com/story/show/162192899)

#### Screenshots (if appropriate)
![autofill](https://user-images.githubusercontent.com/32720508/49077167-f0655d80-f23a-11e8-8253-db3a052cf5e7.gif)


#### Questions:
N/A
