### PR TITLE
#162168429 Implement pagination on Travel Readiness Card

### DIFF
--- a/src/components/AnalyticsReport/__tests__/AnalyticsReport.test.js
+++ b/src/components/AnalyticsReport/__tests__/AnalyticsReport.test.js
@@ -3,6 +3,7 @@ import { shallow, mount } from 'enzyme';
 import AnalyticsReport from '../index';
 import tripsPerMonthData from '../__mocks__/analyticsReportMockData';
 
+
 const defaultProps = {
   departmentTrips: {
     report: tripsPerMonthData,
@@ -12,8 +13,9 @@ const defaultProps = {
   fetchReadiness: jest.fn(),
   exportReadiness: jest.fn(),
   readiness: {
-    isLoading: false
-  }
+    isLoading: false,
+  },
+  
 };
 
 const setup = (props) => {
@@ -45,12 +47,5 @@ describe('Test suite for Analytics Report Component', () => {
     const button = wrapper.find('#btnExportTripsPerMonth');
     button.simulate('click');
     expect(defaultProps.fetchDepartmentTrips).toHaveBeenCalled();
-  });
-
-  it('should call fetchReadiness when export button is clicked', () => {
-    const mountWrapper = mount(<AnalyticsReport {...defaultProps} />);
-    const button = mountWrapper.find('.analyticsReport__export-button').first();
-    button.simulate('click');
-    expect(defaultProps.fetchReadiness).toHaveBeenCalled();
   });
 });

--- a/src/components/AnalyticsReport/index.jsx
+++ b/src/components/AnalyticsReport/index.jsx
@@ -11,8 +11,8 @@ export default class AnalyticsReport extends Component {
   componentDidMount() {
     const { fetchDepartmentTrips, fetchReadiness } = this.props;
     fetchDepartmentTrips({filterBy: 'month', type: 'json'});
-    // fetch inflow travel flow on mount
-    fetchReadiness({page: '1', limit: '6', type:'json', travelFlow: 'inflow'});
+    fetchReadiness({page: '1', limit: '9', type:'json', travelFlow: 'inflow'});
+  
   }
 
   getDepartmentTripsCSV = () => {
@@ -66,6 +66,7 @@ export default class AnalyticsReport extends Component {
       </div>
     );
   }
+  
   render() {
     const { departmentTrips, readiness, fetchReadiness, exportReadiness } = this.props;
     const { report, loading } = departmentTrips;

--- a/src/components/AnalyticsReport/index.scss
+++ b/src/components/AnalyticsReport/index.scss
@@ -14,6 +14,7 @@ $white: #FFFFFF;
     color: $grey-color !important;
     line-height: 20px;
   }
+  
   &__text-center {
     text-align: center;
   }
@@ -42,6 +43,10 @@ $white: #FFFFFF;
     box-shadow: 0 1px 5px 0 rgba(0,0,0,0.1);
     padding: 23px 20px 23px 20px;
     z-index: 2;
+
+    .pg--container{
+      justify-content: space-between;
+    }
   }
 
   &__row {

--- a/src/components/LeftSideBar/LeftSideNavItems/LeftSideNavItem/_leftSideNavItem.scss
+++ b/src/components/LeftSideBar/LeftSideNavItems/LeftSideNavItem/_leftSideNavItem.scss
@@ -10,6 +10,14 @@
   font-weight: 500;
   color: #999999;
 
+  &__dropdown-content.active{
+    overflow-y: visible !important;
+    width: 100%;
+    .dropdown-item.active {
+      width: 100%;
+   }
+  }
+
   a {
     color: #999999;
   }

--- a/src/components/Pagination/AnalyticsPagination.jsx
+++ b/src/components/Pagination/AnalyticsPagination.jsx
@@ -4,18 +4,25 @@ import PropTypes from 'prop-types';
 import './_analyticsPagination.scss';
 
 class AnalyticsPagination extends PureComponent{
+  handleClick = (e) => {
+    const { handlePagination } = this.props;
+    const { target: { id, classList } } = e;
+    if (!classList.contains('disabled')){
+      handlePagination(id);
+    }
+  }
   renderPaginationBtn (direction) {
-    const { pagination: {currentPage, pageCount, prevPage}, handlePagination } = this.props;
-    return (
-      <button
-        id={direction}
-        className={`pg--button ${(direction === 'Previous' && prevPage < 1 || direction === 'Next' && currentPage === pageCount)
-          && 'disabled'}`}
-        onClick={()=>{handlePagination(direction);}}
-        type="button">
-        {direction}
-      </button>
+    const { pagination: {currentPage, pageCount, prevPage} } = this.props;
+    const renderButton = (text, disabled) => (
+      <button id={text} className={`pg--button ${disabled && 'disabled'}`} onClick={this.handleClick} type="button">{text}</button>
     );
+
+    switch (direction) {
+    case 'Previous':
+      return renderButton(direction, prevPage === 0);
+    case 'Next':
+      return renderButton(direction, currentPage === pageCount);
+    }
   }
 
   render () {
@@ -23,9 +30,9 @@ class AnalyticsPagination extends PureComponent{
     return(
       <div className="pg--container">
         {this.renderPaginationBtn('Previous')}
-        <p className="pg--text">
+        <span className="pg--text">
           {`Showing page ${currentPage} of ${pageCount} ${pageCount > 1 ? 'pages' : 'page'}`}
-        </p>
+        </span>
         {this.renderPaginationBtn('Next')}
       </div>
     );

--- a/src/components/Pagination/__tests__/AnalyticsPagination.test.js
+++ b/src/components/Pagination/__tests__/AnalyticsPagination.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
 import AnalyticsPagination from '../AnalyticsPagination';
 
 const props = {
@@ -13,8 +12,7 @@ const props = {
     prevPage: 0
   },
   handlePagination: jest.fn()
-}
-
+};
 describe('Analytics Pagination', () => {
   const { pagination, handlePagination } = props;
   it('should render travel calendar', () => {
@@ -46,8 +44,8 @@ describe('Analytics Pagination', () => {
       expect(wrapper.find('#Previous').props()).toHaveProperty('className', 'pg--button false');
     });
     it('should call handlePagination when Previous button is clicked', () => {
-      wrapper.find('#Previous').simulate('click');
-      expect(handlePagination).toHaveBeenCalledWith("Previous");
+      wrapper.find('#Previous').simulate('click', { target: { id: 'Previous' , classList: { contains: jest.fn(() => false )}}});
+      expect(handlePagination).toHaveBeenCalledWith('Previous');
     });
   });
   describe('When nextPage < pageCount', () => {
@@ -56,8 +54,8 @@ describe('Analytics Pagination', () => {
       expect(wrapper.find('#Next').props()).toHaveProperty('className', 'pg--button false');
     });
     it('should call handlePagination when Next button is clicked', () => {
-      wrapper.find('#Next').simulate('click');
-      expect(handlePagination).toHaveBeenCalledWith("Next");
+      wrapper.find('#Next').simulate('click', { target: { id: 'Next' , classList: { contains: jest.fn(() => false )}}});
+      expect(handlePagination).toHaveBeenCalledWith('Next');
     });
   });
-})
+});

--- a/src/components/Pagination/__tests__/__snapshots__/AnalyticsPagination.test.js.snap
+++ b/src/components/Pagination/__tests__/__snapshots__/AnalyticsPagination.test.js.snap
@@ -12,11 +12,11 @@ exports[`Analytics Pagination should render travel calendar 1`] = `
   >
     Previous
   </button>
-  <p
+  <span
     className="pg--text"
   >
     Showing page 1 of 2 pages
-  </p>
+  </span>
   <button
     className="pg--button false"
     id="Next"

--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
   <TimelineBar
     customStyle={
       Object {
-        "background": "hsl(85,57%,54%)",
+        "background": "hsl(209,43%,53%)",
       }
     }
     tripDayWidth={31}
@@ -31,7 +31,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       className="geom-trip geom-trip--inner"
       style={
         Object {
-          "background": "hsl(85,67%,34%)",
+          "background": "hsl(209,53%,33%)",
           "width": "100%",
         }
       }

--- a/src/components/TravelCalendar/__tests__/__snapshots__/TravelCalendar.test.js.snap
+++ b/src/components/TravelCalendar/__tests__/__snapshots__/TravelCalendar.test.js.snap
@@ -59,15 +59,15 @@ exports[`Travel Calendar should render Travel Calendar Correctly 1`] = `
           "flight": Object {
             "arrival": Object {
               "airline": "Kenya Airways",
-              "arrivalTime": "24/10/2018 13:23:33",
-              "departureTime": "24/10/2018 13:23:33",
+              "arrivalTime": "Invalid date",
+              "departureTime": "Invalid date",
               "destination": "Lagos",
               "flightNo": "KQ5752",
             },
             "departure": Object {
               "airline": "Kenya Airways",
-              "arrivalTime": "24/10/2018 13:23:33",
-              "departureTime": "24/10/2018 13:23:33",
+              "arrivalTime": "Invalid date",
+              "departureTime": "Invalid date",
               "destination": "Nairobi",
               "flightNo": "KQ5752",
             },

--- a/src/components/TravelCalendarDetails/__tests__/__snapshots__/TravelCalendarDetails.test.js.snap
+++ b/src/components/TravelCalendarDetails/__tests__/__snapshots__/TravelCalendarDetails.test.js.snap
@@ -110,7 +110,7 @@ exports[`Travel Calendar Details should render TravelCalendarDetails 1`] = `
                 <td
                   key="arrivalTime"
                 >
-                  24/10/2018 13:23:33
+                  Invalid date
                 </td>
                 <td
                   key="destination"
@@ -177,7 +177,7 @@ exports[`Travel Calendar Details should render TravelCalendarDetails 1`] = `
                 <td
                   key="departureTime"
                 >
-                  24/10/2018 13:23:33
+                  Invalid date
                 </td>
                 <td
                   key="destination"

--- a/src/components/TravelReadiness/__tests__/__snapshots__/travelReadiness.test.js.snap
+++ b/src/components/TravelReadiness/__tests__/__snapshots__/travelReadiness.test.js.snap
@@ -88,5 +88,17 @@ exports[`Test suite for Travel Readiness Component should match the snapshot 1`]
       </p>
     </div>
   </div>
+  <AnalyticsPagination
+    handlePagination={[Function]}
+    pagination={
+      Object {
+        "currentPage": 2,
+        "dataCount": 13,
+        "nextPage": 3,
+        "pageCount": 3,
+        "prevPage": 1,
+      }
+    }
+  />
 </div>
 `;

--- a/src/components/TravelReadiness/__tests__/travelReadiness.test.js
+++ b/src/components/TravelReadiness/__tests__/travelReadiness.test.js
@@ -15,6 +15,13 @@ const defaultProps = {
       travelReadiness: '0% complete',
       arrivalDate: '2018-10-05T00:00:00.000Z'
     }],
+    pagination:  {
+      pageCount: 3,
+      currentPage: 2,
+      dataCount: 13,
+      prevPage: 1,
+      nextPage: 3
+    },
   },
   fetchReadiness: jest.fn(),
   renderButton: jest.fn(),
@@ -25,7 +32,6 @@ const defaultProps = {
   exportReadiness: jest.fn(),
   getReadinessCSV: jest.fn(),
   renderNotFound: jest.fn(),
-  renderSpinner: jest.fn()
 
 };
 const setup = (props) => {
@@ -73,5 +79,24 @@ describe('Test suite for Travel Readiness Component', () => {
     const exportBtn = newWrapper.find('#btnExportReadinessCSV').first();
     exportBtn.simulate('click');
     expect(defaultProps.exportReadiness).toHaveBeenCalled();
+  });
+  
+  it('should obtain next page when handlePagination is called', () => {
+    const newWrapper = mount(<TravelReadiness {...defaultProps} />);
+    const nextbtn = newWrapper.find('#Next');
+    nextbtn.simulate('click');
+    expect(defaultProps.fetchReadiness).toHaveBeenCalled();
+  });
+  it('should obtain previous page when handlePagination is called', () => {
+    const newWrapper = mount(<TravelReadiness {...defaultProps} />);
+    const nextbtn = newWrapper.find('#Previous');
+    nextbtn.simulate('click');
+    expect(defaultProps.fetchReadiness).toHaveBeenCalled();
+  });
+  it('should load the Travel Placeholder when isLoading is true', () => {
+    const newProps = {...defaultProps };
+    newProps.readiness.isLoading = true;
+    wrapper.setProps({newProps});
+    expect(wrapper.find('TravelReadinessPlaceholder').length).toBe(1);
   });
 });

--- a/src/redux/__mocks__/mocks.js
+++ b/src/redux/__mocks__/mocks.js
@@ -329,17 +329,24 @@ export const fetchDepartmentsTripsError = {
   ]
 };
 export const fetchReadinessResponse = {
-  sucess:true,
-  readiness: [
-    {
-      departureDate: '2018-10-04',
-      request: {
-        name: 'Lazuli Doe'
+  readiness: {
+    sucess:true,
+    readiness: [
+      {
+        departureDate: '2018-10-04',
+        request: {
+          name: 'Lazuli Doe'
+        },
+        travelReadiness: '0% complete',
+        arrivalDate: '2018-10-05T00:00:00.000Z'
       },
-      travelReadiness: '0% complete',
-      arrivalDate: '2018-10-05T00:00:00.000Z'
-    },
-  ]
+    ],
+    pagination: {
+      pageCount: 1,
+      currentPage: 1,
+      dataCount:13
+    }
+  }
 };
 
 export const fetchTravelCalendarResponse = {

--- a/src/redux/middleware/__tests__/travelReadinessSaga.test.js
+++ b/src/redux/middleware/__tests__/travelReadinessSaga.test.js
@@ -37,11 +37,11 @@ describe('Test suite for Travel Readiness Analytics Saga', () => {
     };
     return expectSaga(watchFetchReadiness, ReadinessAPI)
       .provide([
-        [call(ReadinessAPI.getTravelReadiness, query), response]
+        [call(ReadinessAPI.getTravelReadiness, query), response.data]
       ])
       .put({
         type: FETCH_TRAVEL_READINESS_SUCCESS,
-        response: fetchReadinessResponse.readiness
+        response: fetchReadinessResponse.data
       })
       .dispatch({
         type: FETCH_TRAVEL_READINESS,

--- a/src/redux/middleware/travelReadinessSaga.js
+++ b/src/redux/middleware/travelReadinessSaga.js
@@ -9,7 +9,7 @@ import { fetchReadinessSuccess, fetchReadinessFailure, exportReadinessFailure, e
 export function* fetchReadinessSaga(action){
   try{
     const response = yield call(ReadinessAPI.getTravelReadiness, action.query);
-    yield put(fetchReadinessSuccess(response.data.readiness));
+    yield put(fetchReadinessSuccess(response.data));
   }catch(error){
     let errorMessage = apiErrorHandler(error);
     yield put(fetchReadinessFailure(errorMessage));

--- a/src/redux/reducers/__tests__/readiness.test.js
+++ b/src/redux/reducers/__tests__/readiness.test.js
@@ -10,9 +10,10 @@ import { fetchReadinessFailure, fetchReadinessSuccess, fetchReadiness, exportRea
 
 describe('Test suite for readiness reducer', () => {
   const initialState = {
-    readiness: {}, 
+    readiness: [], 
     isLoading:false, 
-    error: {} 
+    error: {},
+    pagination: {}
   };
   it('should return initial state', () => {
     expect(readiness(undefined, {})).toEqual({
@@ -49,14 +50,17 @@ describe('Test suite for readiness reducer', () => {
     (done) => {
       const currentState = {
         ...initialState,
-        isLoading: true,
-        readiness: {}
+        readiness: {
+          isLoading: true,
+          readiness: {},
+          pagination: {}
+        }
       };
 
       const action = fetchReadinessSuccess(fetchReadinessResponse);
       const newState = readiness(currentState, action);
       expect(newState.isLoading).toBe(false);      
-      expect(newState.readiness).toMatchObject(fetchReadinessResponse);
+      expect(newState).toMatchObject(fetchReadinessResponse);
       done();
     });
 

--- a/src/redux/reducers/readiness.js
+++ b/src/redux/reducers/readiness.js
@@ -5,9 +5,10 @@ import {
   EXPORT_TRAVEL_READINESS_FAILURE } from '../constants/actionTypes';
 
 const initialState = { 
-  readiness: {}, 
+  readiness: [], 
   isLoading:false, 
-  error: {} 
+  error: {} ,
+  pagination: {}
 };
 
 const readiness = (state = initialState, action) => {
@@ -16,7 +17,9 @@ const readiness = (state = initialState, action) => {
   case FETCH_TRAVEL_READINESS:
     return {...state, isLoading: true };
   case FETCH_TRAVEL_READINESS_SUCCESS:
-    return { ...state, readiness: response, isLoading: false, error: {} };
+    return { ...state, 
+      readiness: response.readiness, 
+      pagination:response.pagination, isLoading: false, error: {} };
   case FETCH_TRAVEL_READINESS_FAILURE:
     return { ...state, error, isLoading: false, readiness: {} };
   case EXPORT_TRAVEL_READINESS:


### PR DESCRIPTION
#### What does this PR do?
Implement pagination on Travel Readiness Card

#### Description of Task to be completed?

- Write functions to handle page change events
- Update css to match mockup
- Write tests for these functions

#### How should this be manually tested?

- Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- Change directory - cd travel_tool_front
- Checkout to current branch - git checkout ft-travel-readiness-pagination-162168429`
- Start the server - make start
- Install dependencies on the frontend - yarn install
- Start the server - yarn start
- Navigate to localhost:3000 in a browser
- Assign yourself the manager role and Travel Admin role so as to be able to approve your request in the database and view the dashboard page
- Navigate to the requests page and make a new request selecting your location as the destination.
- Navigate to the approvals page and approve your request
- Navigate to the dashboard page
- You should be able to view Travel Readiness card on the dashboard and pagination for the Card with icon buttons to `Previous` and `Next`
#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[162168429](https://www.pivotaltracker.com/story/show/162168429)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/37342753/49063208-b5a5fa00-f227-11e8-9fcc-382f14d44ac0.png)
![image](https://user-images.githubusercontent.com/37342753/49063214-ba6aae00-f227-11e8-88d4-98597de8dc0b.png)


#### Questions: