### PR TITLE
#162232273 Allow travel team members to view dashboard

### DIFF
--- a/src/components/AnalyticsReport/__tests__/__snapshots__/AnalyticsReport.test.js.snap
+++ b/src/components/AnalyticsReport/__tests__/__snapshots__/AnalyticsReport.test.js.snap
@@ -12,9 +12,7 @@ exports[`Test suite for Analytics Report Component should match the snapshot 1`]
         "isLoading": false,
       }
     }
-    renderButton={[Function]}
     renderNotFound={[Function]}
-    renderSpinner={[Function]}
   />
   <div
     className="analyticsReport__card"

--- a/src/components/LeftSideBar/Metadata/index.js
+++ b/src/components/LeftSideBar/Metadata/index.js
@@ -19,7 +19,7 @@ const NavItemsMetadata = [
     link_to: '/dashboard',
     activateOnLogin: true,
     exact: true,
-    onlyVisibleTo: ['Travel Administrator', 'Super Administrator'],
+    onlyVisibleTo: ['Travel Administrator', 'Super Administrator', 'Travel Team Member'],
     icons: {
       active: activeDashboardIcon,
       inactive: inactiveDashboardIcon

--- a/src/components/LeftSideBar/__tests__/__snapshots__/LeftSideBar.test.js.snap
+++ b/src/components/LeftSideBar/__tests__/__snapshots__/LeftSideBar.test.js.snap
@@ -25,6 +25,7 @@ exports[`<LeftSideBar /> renders correctly 1`] = `
               "onlyVisibleTo": Array [
                 "Travel Administrator",
                 "Super Administrator",
+                "Travel Team Member",
               ],
               "text": "Dashboard",
             },

--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
@@ -8,14 +8,14 @@ exports[`<TripGeometry /> renders correctly 1`] = `
     Object {
       "length": 7,
       "stayPercentage": "100%",
-      "tripTimelineOffsetLeft": -10261,
+      "tripTimelineOffsetLeft": -10230,
     }
   }
 >
   <TimelineBar
     customStyle={
       Object {
-        "background": "hsl(124,69%,56%)",
+        "background": "hsl(102,45%,69%)",
       }
     }
     tripDayWidth={31}
@@ -23,7 +23,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       Object {
         "length": 7,
         "stayPercentage": "100%",
-        "tripTimelineOffsetLeft": -10261,
+        "tripTimelineOffsetLeft": -10230,
       }
     }
   >
@@ -31,7 +31,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       className="geom-trip geom-trip--inner"
       style={
         Object {
-          "background": "hsl(124,79%,36%)",
+          "background": "hsl(102,55%,49%)",
           "width": "100%",
         }
       }

--- a/src/components/TravelReadiness/__tests__/__snapshots__/travelReadiness.test.js.snap
+++ b/src/components/TravelReadiness/__tests__/__snapshots__/travelReadiness.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Test suite for Travel Readiness Component should match the snapshot 1`] = `
 <div
   className="analyticsReport__card"
+  id="travel-readiness"
   style={
     Object {
       "marginRight": "30px",

--- a/src/components/TravelReadiness/index.jsx
+++ b/src/components/TravelReadiness/index.jsx
@@ -1,6 +1,5 @@
-
 import React, { Component, Fragment } from 'react';
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 import generateDynamicDate from '../../helper/generateDynamicDate';
 import download from '../../images/icons/save_alt_24px.svg';
 import Button from '../buttons/Buttons';
@@ -26,33 +25,33 @@ class TravelReadiness extends Component {
         </div>
       </div>
     );
-  }
-  
+  };
+
   getReadinessCSV = () => {
     const { exportReadiness } = this.props;
-    const { travelFlow } = this.state; 
+    const { travelFlow } = this.state;
     exportReadiness({ type: 'file', travelFlow: travelFlow});
-  }
-  
+  };
+
   getTravelFlow = travelArgument => {
     const { fetchReadiness } = this.props;
     this.setState({
       travelFlow: travelArgument
     });
     fetchReadiness({page: '1', limit: '6', type:'json', travelFlow: travelArgument});
-  }
+  };
 
   travelFlowButton = () => {
     const { travelFlow } = this.state;
     const travelButton = (
       <Fragment>
-        <button 
-          className="travel-readiness-toggle-button-0" type="button" 
-          id={travelFlow !== 'outflow' ? 'active-travel-flow-button' : null} 
+        <button
+          className="travel-readiness-toggle-button-0" type="button"
+          id={travelFlow !== 'outflow' ? 'active-travel-flow-button' : null}
           onClick={() => this.getTravelFlow('inflow')}>
         Inflow
         </button>
-        <button 
+        <button
           className="travel-readiness-toggle-button-1" type="button"
           id={travelFlow === 'outflow' ? 'active-travel-flow-button' : null}
           onClick={() => this.getTravelFlow('outflow')}>
@@ -61,15 +60,15 @@ class TravelReadiness extends Component {
       </Fragment>
     );
     return travelButton;
-  }
+  };
 
   render() {
-    const { readiness, renderNotFound, renderButton } = this.props;
+    const { readiness, renderNotFound } = this.props;
     const { isLoading} = readiness;
     const { travelFlow } = this.state;
     return (
-      <div className="analyticsReport__card" style={{marginRight: '30px'}}>
-        {isLoading ? 
+      <div className="analyticsReport__card" id="travel-readiness" style={{marginRight: '30px'}}>
+        { isLoading ?
           <TravelReadinessPlaceholder /> : (
             <Fragment>
               <p>Travel Readiness</p>
@@ -77,8 +76,8 @@ class TravelReadiness extends Component {
                 {this.travelFlowButton()}
                 <Button
                   buttonClass="analyticsReport__export-button"
-                  reverseText buttonId="btnExportReadinessCSV" 
-                  text="Export" imageSrc={download} 
+                  reverseText buttonId="btnExportReadinessCSV"
+                  text="Export" imageSrc={download}
                   onClick={travelFlow === 'outflow' ? () => this.getReadinessCSV('outflow') : () => this.getReadinessCSV('inflow')} />
               </div>
               <div className="analyticsReport__row analyticsReport__report-header">
@@ -105,7 +104,6 @@ TravelReadiness.propTypes = {
   readiness: PropTypes.object.isRequired,
   exportReadiness:PropTypes.func.isRequired,
   fetchReadiness: PropTypes.func.isRequired,
-  renderButton: PropTypes.func.isRequired,
   renderNotFound: PropTypes.func.isRequired
 };
 

--- a/src/views/Dashboard/index.jsx
+++ b/src/views/Dashboard/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -21,8 +22,8 @@ export class Dashboard extends Component {
       history, getCurrentUserRole, isLoaded, exportReadiness, travelCalendar, fetchCalendarAnalytics,
       downloadCalendarAnalytics, downloadAnalytics } = this.props;
     if (isLoaded) {
-      const allowedRoles = ['Travel Administrator', 'Super Administrator'];
-      checkUserPermission(history, allowedRoles, getCurrentUserRole );
+      const allowedRoles = ['Travel Administrator', 'Super Administrator', 'Travel Team Member'];
+      checkUserPermission(history, allowedRoles, getCurrentUserRole);
     }
     return (
       <div id="dashboard">


### PR DESCRIPTION
#### What does this PR do?
Allows Users with the role 'Travel Team Member' to access the dashboard.

#### Description of Task to be completed?
- add 'Travel Team Member' to included permissions to view the dashboard
- add 'Travel Team Member' to included permissions for the navigation
  link to the dashboard.

#### How should this be manually tested?
- Clone the repo
    `git clone https://github.com/andela/travel_tool_front.git`
 - Switch to the project directory
   `cd travel_tool_front`
 - Checkout the **ch-travel-team-views-dashboard-162232273** branch
   `git checkout ch-travel-team-views-dashboard-162232273`
 - Install dependencies and start the server
   - `make start` *if you have docker*
   - `yarn install` then `yarn start` *if you do not have docker*
 - Start the [backend](https://github.com/andela/travel_tool_back/pull/188) of this project.
 - Navigate to [travela](http://travela-local.andela.com:3000/) in your browser and log in with your Andela account. 
 - You should be able to view the dashboard as a Travel Team Member.

#### Any background context you want to provide?
You will need the backend PR ([#188](https://github.com/andela/travel_tool_back/pull/188)) locally running and the instructions followed.

#### What are the relevant pivotal tracker stories?
* [#162232273](https://www.pivotaltracker.com/story/show/162232273)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A