### PR TITLE
#162261103 Fix text-area misalignment 

### DIFF
--- a/src/components/TravelCheckList/travelSubmission.scss
+++ b/src/components/TravelCheckList/travelSubmission.scss
@@ -130,7 +130,7 @@
                     color: #4f4f4f;
                     text-transform: capitalize;
                     text-align: left;
-                    text-indent: 14px;
+                    text-indent: 5px;
                     outline: none;
                 }
                 input[type=datetime-local] {
@@ -174,9 +174,6 @@
                 color: #4f4f4f;
                 height: 41px;
                 width: 100%;
-                right: 41px;
-                margin-bottom: 10px;
-                outline: none
             }
         }
     }


### PR DESCRIPTION
#### What does this PR do?
It enables users to use Grammarly while uploading checklist submissions and re-aligns the date and time locations.

#### Description of Task to be completed?
- Time and date should be aligned more to the left
- Grammarly injection should be possible without distorting the text area field

#### How should this be manually tested?
- Clone this branch `git clone -b bg-fix-grammarly-misalignment-162261103 https://github.com/andela/travel_tool_front.git`
- Start server `make start`
- Navigate to travela in your browser and log in
- Create a request and change its status to `Approved`
- Click the dropdown-menu ellipsis
- Click `Travel Checklist`
- Ensure Grammarly is turned on
- Start typing in the text-area. It should not be misaligned or distorted. 

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?
[162261103](https://www.pivotaltracker.com/story/show/162261103)

#### Screenshots (if appropriate)

##### file upload
![image](https://user-images.githubusercontent.com/30747298/49154317-1ff29380-f329-11e8-9232-f2f2a1c0df13.png)

#### Questions:
