### PR TITLE
#162304867 Modify label on Trips card

### DIFF
--- a/src/components/AnalyticsReport/index.jsx
+++ b/src/components/AnalyticsReport/index.jsx
@@ -82,7 +82,7 @@ export default class AnalyticsReport extends Component {
           {loading ? <TripsPerMonthPlaceholder /> : (
             <Fragment>
               <div className="analyticsReport__row analyticsReport__header">
-                <p>Number of Trips/Month</p>
+                <p>Number of Trips per Department</p>
                 {this.renderButton('btnExportTripsPerMonth', download, 'Export', this.getDepartmentTripsCSV)}
               </div>
               <div className="analyticsReport__row analyticsReport__report-header">


### PR DESCRIPTION
#### What does this PR do?
Update card label to correspond with content of card

#### Description of Task to be completed?
- update label to read "Number of trips per department"

#### How should this be manually tested?
- Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- checkout this branch - `git checkout bg-fix-card-label-162304867`
- run `yarn start`
- Clone the backend repo - `git clone https://github.com/andela/travel_tool_back.git`
- run `yarn db:rollmigrate` on the backend directory and run `yarn start:dev`
- login to the app as a manager
- go to `http://localhost:3000/dashboard`
- scroll to the analytics cards.

#### Any background context you want to provide?
- Card Label previously read as "Number of Trips/ Month"
- You must be logged in with a role of manager or higher to view dashboard page

#### What are the relevant pivotal tracker stories?
[#162304867](https://www.pivotaltracker.com/story/show/162304867)

#### Screenshots (if appropriate)
<img width="1440" alt="screenshot 2018-11-29 at 1 42 51 pm" src="https://user-images.githubusercontent.com/25967737/49222654-b3d16780-f3dc-11e8-88be-142d1b282acc.png">

#### Questions:
None