### PR TITLE
#162310451 Fix bug on renaming a travel document.

### DIFF
--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
   <TimelineBar
     customStyle={
       Object {
-        "background": "hsl(144,36%,61%)",
+        "background": "hsl(177,63%,64%)",
       }
     }
     tripDayWidth={31}
@@ -31,7 +31,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       className="geom-trip geom-trip--inner"
       style={
         Object {
-          "background": "hsl(144,46%,41%)",
+          "background": "hsl(177,73%,44%)",
           "width": "100%",
         }
       }

--- a/src/components/TravelCalendar/index.jsx
+++ b/src/components/TravelCalendar/index.jsx
@@ -58,7 +58,7 @@ class TravelCalendar extends PureComponent {
       if(direction === 'Previous' && prevPage > 0) {
         this.setState(prevState => ({ ...prevState, page: prevPage }));
         fetchCalendarAnalytics({type: 'json', filter, page: prevPage});
-      } else if(direction === 'Next' && currentPage <= pageCount) {
+      } else if(direction === 'Next' && (currentPage + 1) <= pageCount) {
         this.setState(prevState => ({ ...prevState, page: nextPage }));
         fetchCalendarAnalytics({type: 'json', filter, page: nextPage});
       }

--- a/src/views/Documents/__tests__/index.test.js
+++ b/src/views/Documents/__tests__/index.test.js
@@ -222,12 +222,19 @@ describe('<Documents />', () => {
     expect(mapper.documents).toEqual(['user documents']);
   });
 
-  it('should should render documents editmodal', (done) => {
+  it('should render documents editmodal', (done) => {
     const currentProps = { ...props, modalType: 'rename document' };
     const wrapper = mount(<Documents {...currentProps} />);
     const toggleIcons = wrapper.find('#toggleIcon');
     const toggleMenuSpy = jest.spyOn(wrapper.instance(), 'toggleMenu');
     expect(toggleIcons.length).toBe(2);
     done();
+  });
+  describe('textValidator',() => {
+    it('should return true when a non string is passed as an argument',() => {
+      const wrapper = shallow(<Documents {...props} />);
+      const resultValue = wrapper.instance().textValidator('    ');
+      expect(resultValue).toBe(true);
+    });
   });
 });

--- a/src/views/Documents/index.js
+++ b/src/views/Documents/index.js
@@ -19,7 +19,8 @@ export class Documents extends Component {
     menuOpen: { open: false, id: null },
     documentId: null,
     documentToDelete: '',
-    documentToDownlod: ''
+    documentToDownlod: '',
+    hasBlankFields: true
   };
   componentDidMount() {
     const { fetchDocuments } = this.props;
@@ -75,15 +76,21 @@ export class Documents extends Component {
 
   handleRenameDocument = () => {
     const { documentOnEdit, updateDocument } = this.props;
+    this.setState({ hasBlankFields: true});
     updateDocument(documentOnEdit);
   }
   handleInputChange = (event) => {
     const { value } = event.target;
     const { documentOnEdit, updateDocumentOnEdit } = this.props;
+    this.setState({ hasBlankFields: this.textValidator(value)});
     documentOnEdit && updateDocumentOnEdit(value);
   }
-
-
+   textValidator = (value) => {
+     const isString = typeof(value) === 'string' &&
+     (value.replace(/\s+/, '')).length > 0 ;
+     if (isString) return false;
+     return true;
+   }
 
   handleSubmitDownload = () => {
     const { documentToDownlod: { name } } = this.state; return (
@@ -131,6 +138,7 @@ export class Documents extends Component {
   }
   renderSubmitArea = () => {
     const { isUpdating } = this.props;
+    const { hasBlankFields } = this.state;
     return (
       <div className="submit-area">
         <p>
@@ -146,7 +154,7 @@ export class Documents extends Component {
             type="button"
             className="bg-btn bg-btn--inactive doc-btn-save"
             id="cancel"
-            disabled={isUpdating}
+            disabled={hasBlankFields}
             onClick={this.handleRenameDocument}
           >
             <ButtonLoadingIcon isLoading={isUpdating} buttonText="Save" />


### PR DESCRIPTION
#### What does this PR do?
- by default disable save button on the rename document modal
- disable the next button on the calendar details from navigating to the next page when clicked

#### Description of Task to be completed?
- The save button should be disabled by default unless the user changes the name of the document.
- When all the records have been fetched the button should be disabled and not clickable.

#### How should this be manually tested?
- Setting up the backend
     - Clone the repo - `git clone https://github.com/andela/travel_tool_back.git`
     - Enter into the project directory - `cd travel_tool_back`
     - checkout the branch git checkout `develop`
     - Install dependencies using `yarn install`
     - Rollback and run database migrations with `yarn db:rollmigrate`
     - start the backend server with `yarn run start:dev`


- Setting up the frontend
   - Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
   - Enter into the project directory - `cd travel_tool_front`
   - Checkout to the branch `bg-rename-travel-document-162310451` then run the app `yarn start`
   - Login to the application
   - Navigate to the documents page as a requester user and add a new travel document
   - Try editing the document
   - It is expected that the save button would be disabled by default.

   - As an administrator who has more than three travel request departing from your centre, Navigate to Dashboard and scroll to the calendar details.
   - Click next button more than the number of pages loaded.
   - It is expected that the button would become disabled once the all records have been fetched.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162310451](https://www.pivotaltracker.com/story/show/162310451)

#### Screenshots (if appropriate)
- Travel calendar section

<img width="1170" alt="screen shot 2018-11-30 at 18 48 59" src="https://user-images.githubusercontent.com/21138053/49299402-b57c5780-f4d0-11e8-84fe-d5bc82b50cc6.png">

- Rename document modal
<img width="1137" alt="screen shot 2018-11-30 at 18 53 29" src="https://user-images.githubusercontent.com/21138053/49299671-64b92e80-f4d1-11e8-9507-dbca2432ae8d.png">
