### PR TITLE
#161877486 User can view details of a request(End-to-end test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 .env
 
+#end-to-end
+cypress.env.json
 
 # misc
 .env

--- a/cypress/integration/component/Requests/request.spec.js
+++ b/cypress/integration/component/Requests/request.spec.js
@@ -7,8 +7,7 @@ describe('Requests', () => {
 
   describe('New User\'s request page', () => {
     before(() => {
-      const token = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySW5mbyI6eyJpZCI6Ii1MSEptS3J4QThTbFBOUUZPVlZtIiwiZmlyc3RfbmFtZSI6IkFtYXJhY2h1a3d1IiwibGFzdF9uYW1lIjoiQWdibyIsImZpcnN0TmFtZSI6IkFtYXJhY2h1a3d1IiwibGFzdE5hbWUiOiJBZ2JvIiwiZW1haWwiOiJhbWFyYWNodWt3dS5hZ2JvQGFuZGVsYS5jb20iLCJuYW1lIjoiQW1hcmFjaHVrd3UgQWdibyIsInBpY3R1cmUiOiJodHRwczovL2xoNC5nb29nbGV1c2VyY29udGVudC5jb20vLUo4eVFYZHR2TkJJL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFBL0FHRGd3LWktZXZvMElaZ0JHYVFBZWgyY25OSUZRRUlKYncvbW8vcGhvdG8uanBnP3N6PTUwIiwicm9sZXMiOnsiVGVjaG5vbG9neSI6Ii1LWEg3aU1FNGViTUVYQUVjN0hQIiwiQW5kZWxhbiI6Ii1LaWloZlpvc2VRZXFDNmJXVGF1In19LCJpYXQiOjE1NDI5MDE3MTksImV4cCI6MTU0NTQ5MzcxOSwiYXVkIjoiYW5kZWxhLmNvbSIsImlzcyI6ImFjY291bnRzLmFuZGVsYS5jb20ifQ.Hfm3FGyu0pZRbRniRsvUZXOMVEogPE4t8R2vnOkrJfifsleYRa1NXaoZ1cTwwrkUpLCCclpCAkHCWsy2p05FVsbOiVZmHLlH88Er2xJHxinlCOhWWAHYkWgh8pPTt3csplC8hS2h4ZyVBz7ghvizNbyHiRP_XkPx_aAUHnQ7ICA';
-      cy.authenticateUser(token);
+      cy.authenticateUser();
       cy.visit('/requests');
     });
 

--- a/cypress/integration/component/Requests/view-request-details.spec.js
+++ b/cypress/integration/component/Requests/view-request-details.spec.js
@@ -1,0 +1,119 @@
+import moment from 'moment';
+
+describe('Requests Page(view request details)', () => {
+  let request;
+  before(() => {
+    cy.authenticateUser();
+    cy.visit('/requests');
+    cy.server();
+    cy.route('POST', 'http://127.0.0.1:5000/api/v1/requests').as(
+      'createRequest'
+    ); // Used to check when request is POST completed
+    // Fill form data
+    cy.get('button.action-btn.btn-new-request').as('request-button');
+    cy.get('@request-button').click();
+    cy.get('input[name=name]')
+      .clear()
+      .type('Another test user');
+    cy.get('button[name=gender]:last').click();
+    cy.get('div[name=department]').click();
+    cy.get('div[name=department] > ul > li#choice:first').click();
+    cy.get('div[name=manager]').click();
+    cy.get('div[name=manager] > ul > li#choice:first').click();
+    cy.get('input.occupationInput')
+      .clear()
+      .type('Software developer');
+    cy.get('input[name=origin-0]')
+      .type('Kigali')
+      .wait(2000)
+      .type('{downarrow}{enter}');
+    cy.get('input[name=destination-0]')
+      .type('Nairobi')
+      .wait(2000)
+      .type('{downarrow}{enter}');
+    cy.get('input[name=departureDate-0]').click();
+    cy.get('.react-datepicker__day--today')
+      .next()
+      .click();
+    cy.get('input[name=arrivalDate-0]').click();
+    cy.get('.react-datepicker__day--today')
+      .next()
+      .next()
+      .click();
+    cy.get('div[name=bed-0]').click();
+    cy.get('div[name=bed-0] > ul > li#choice:first')
+      .wait(2000)
+      .click();
+    // Submit form
+    cy.get('button#submit')
+      .as('submit')
+      .should('not.be.disabled')
+      .click();
+    cy.wait('@createRequest').then(createdRequest => {
+      request = createdRequest.response.body.request;
+    });
+  });
+
+  it(`should open the request details modal when the
+  requestId is clicked`, () => {
+    cy.server();
+    cy.route(`http://127.0.0.1:5000/api/v1/requests/${request.id}`).as(
+      'getRequest'
+    );
+    cy.get('.table__row')
+      .eq(0)
+      .find('td')
+      .eq(0)
+      .find('.button-outline')
+      .click();
+    cy.get('.modal')
+      .should('be.visible')
+      .contains(`${request.id} Request Details`);
+    cy.get('.request-details').should('be.visible');
+  });
+
+  it('should display details of the request', () => {
+    cy.get('.modal').then(() => {
+      cy.get('.lable-text').contains('Manager Stage');
+      cy.get('.modal__user-info').contains('Another test user'); // user's name
+      cy.get('.modal__user-info > img').should(
+        'have.attr',
+        'src',
+        request.picture
+      ); // user's avatar
+      cy.get('.user-role').contains('Software developer, Talent & Development');
+      cy.get('.request__status--open').contains('Open');
+      cy.get('.request-type').contains('Return Trip');
+      cy.get('.modal__trip-detail')
+        .eq(0)
+        .contains('Kigali, Rwanda'); // origin
+      cy.get('.modal__trip-detail')
+        .eq(1)
+        .contains('Nairobi, Kenya'); //destination
+      cy.get('.modal__trip-detail')
+        .eq(2) // departure date
+        .contains(moment(request.trips[0].departureDate).format('DD MMM YYYY'));
+      cy.get('.modal__trip-detail')
+        .eq(3) // return date
+        .contains(moment(request.trips[0].returnDate).format('DD MMM YYYY'));
+      cy.get('.modal__add-comment')
+        .should('be.visible')
+        .contains('Add a comment');
+    });
+  });
+
+  it('displays the WSISWYG editor', () => {
+    cy.get('.editor__editor-form').within(() => {
+      cy.get('.quill').should('be.visible');
+      cy.get('.editor__btn-wrap > button#post-submit')
+        .contains('Post')
+        .should('be.disabled');
+    });
+  });
+
+  it(`closes the request details modal when the
+  close button is clicked`, () => {
+    cy.get('button.modal-close').click();
+    cy.get('.modal').should('not.be.visible');
+  });
+});

--- a/cypress/integration/component/logout.spec.js
+++ b/cypress/integration/component/logout.spec.js
@@ -1,10 +1,7 @@
 describe('Logout User', () => {
 
   it('should set token in cookie', () => {
-    cy.setCookie(
-      'jwt-token',
-      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJVc2VySW5mbyI6eyJpZCI6Ii1MSEpsR2haOUhpTmxkVnQtakItIiwiZmlyc3RfbmFtZSI6IlRhaXdvIiwibGFzdF9uYW1lIjoiU3VuZGF5IiwiZmlyc3ROYW1lIjoiVGFpd28iLCJsYXN0TmFtZSI6IlN1bmRheSIsImVtYWlsIjoidGFpd28uc3VuZGF5QGFuZGVsYS5jb20iLCJuYW1lIjoiVGFpd28gU3VuZGF5IiwicGljdHVyZSI6Imh0dHBzOi8vbGg2Lmdvb2dsZXVzZXJjb250ZW50LmNvbS8tbVFaMDc3ODdiYTgvQUFBQUFBQUFBQUkvQUFBQUFBQUFBQWMvcUM2LUEyY1dBRUEvcGhvdG8uanBnP3N6PTUwIiwicm9sZXMiOnsiVGVjaG5vbG9neSI6Ii1LWEg3aU1FNGViTUVYQUVjN0hQIiwiQW5kZWxhbiI6Ii1LaWloZlpvc2VRZXFDNmJXVGF1In19LCJpYXQiOjE1NDI0ODA2NzEsImV4cCI6MTU0NTA3MjY3MSwiYXVkIjoiYW5kZWxhLmNvbSIsImlzcyI6ImFjY291bnRzLmFuZGVsYS5jb20ifQ.s4VHIRIGAZ3ZegVDXvIs6s0uCU_1bQo6LNlpGBoztuFK1cLBJrfOc1qfVAKc0d2dC9DDS5LrT-on3_9h37oqRowOdUVesOq2ipaHmlfX4jM4jAlaJaQKKRLX5W4UNOrq769CjgZkheYICx9afFowb14A3iQIhtWwbbWTW4YZeLA'
-    );
+    cy.authenticateUser();
     cy.visit('/requests');
   });
 
@@ -21,7 +18,7 @@ describe('Logout User', () => {
   });
 
   it('should check the Url', () => {
-    cy.url().should('eq', 'http://localhost:3000/');     
+    cy.url().should('eq', 'http://localhost:3000/');
     cy.get('.toast-message').should('be.visible');
   });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,5 @@
-Cypress.Commands.add('authenticateUser', (token) => {
+const testToken = Cypress.env('token');
+
+Cypress.Commands.add('authenticateUser', (token = testToken) => {
   cy.setCookie('jwt-token', token);
 });


### PR DESCRIPTION
#### What does this PR do?
Adds end-to-end tests that ensure that users can view details of a request

#### Description of Task to be completed?
- Create a request
- Add tests to ensure that the user can view the details of the request

#### How should this be manually tested?
- Open the terminal 
- Create `cypress.env.json` file in the root directory and add your token following the format:
``{
"token": "your_token"
}``
- Run `yarn end2end` to run the test with browser mode
- When redirected to the browser, select `component/Requests/view-request-details.spec.js`
- The tests should run and pass
- To run test only in the console, run `yarn end2end:headless` 

#### Any background context you want to provide?
- Ensure both the frontend and backend servers are running

#### What are the relevant pivotal tracker stories?
[#161877486](https://www.pivotaltracker.com/story/show/161877486)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A