### PR TITLE
#162305445 Fix colour scheme in dashboard pie charts

### DIFF
--- a/src/components/PieChartAnalytics/__tests__/PieChartAnalytics.test.js
+++ b/src/components/PieChartAnalytics/__tests__/PieChartAnalytics.test.js
@@ -3,7 +3,20 @@ import { shallow } from 'enzyme';
 import PieChartAnalytics, { renderCustomizedLabel } from '..';
 
 const props = {
-  data: []
+  data: [
+    {
+      name: '2 days',
+      value: 3,
+    },
+    {
+      name: '3 days',
+      value: 2,
+    },
+    {
+      name: '5 days',
+      value: 1,
+    },
+  ]
 };
 
 describe('<Dashboard />', () => {

--- a/src/components/PieChartAnalytics/index.jsx
+++ b/src/components/PieChartAnalytics/index.jsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { PieChart, Pie } from 'recharts';
+import { PieChart, Pie, Cell } from 'recharts';
 import PropTypes from 'prop-types';
 
 export const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent, name }) => {
@@ -26,7 +26,7 @@ export const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadi
   );
 };
 
-const PieChartAnalytics = ({data}) => (
+const PieChartAnalytics = ({data, color}) => (
   <Fragment>
     {(data.length > 0 && data[0].name !== '') ? (
       <PieChart width={250} height={200}>
@@ -37,7 +37,26 @@ const PieChartAnalytics = ({data}) => (
           label={renderCustomizedLabel}
           labelLine={false}
           dataKey="value"
-        />
+        >
+          {
+            data.map((entry, index) => {
+              const maxLightness = 90;
+              const minLightness = 50;
+              const lightnessRange = maxLightness - minLightness;
+
+              const entries = data.slice().sort((a, b) => b.value - a.value);
+              const maxEntryValue = entries[0].value;
+              const minEntryValue = entries[entries.length - 1].value;
+
+              let lightnessDiff = lightnessRange / (maxEntryValue - minEntryValue);
+              lightnessDiff = isFinite(lightnessDiff) ? lightnessDiff : 0;
+              const lightness = ((maxEntryValue - entry.value) * lightnessDiff) + 50;
+              return color === 'orange' ?
+                <Cell fill={`hsl(226, 70%, ${lightness}%)`} /> :
+                <Cell fill={`hsl(37, 99%, ${lightness}%)`} />;
+            })
+          }
+        </Pie>
       </PieChart>
     ) : (
       <div className="chart-data">
@@ -69,10 +88,12 @@ renderCustomizedLabel.defaultProps = {
 
 PieChartAnalytics.propTypes = {
   data: PropTypes.array,
+  color: PropTypes.string,
 };
 
 PieChartAnalytics.defaultProps = {
-  data: []
+  data: [],
+  color: '',
 };
 
 export default  PieChartAnalytics;

--- a/src/views/Analytics/index.jsx
+++ b/src/views/Analytics/index.jsx
@@ -77,14 +77,14 @@ export class Analytics extends Component {
           <div className="analytics">
             {this.renderCards('Total No. of Travel Requests', {stats: totalRequests, icon: flightIcon} )}
             {this.renderCards('Total Number of Pending Requests', {stats: pendingRequests, icon: pendingIcon}, '/requests/my-verifications')}
-            {this.renderCards('Average Travel Duration', {data: (analytics.success ? travelDurationBreakdown.durations : []), chart: true})}
+            {this.renderCards('Average Travel Duration', {data: (analytics.success ? travelDurationBreakdown.durations : []), chart: true, color: 'blue'})}
             {this.renderCards(`No. of People visiting ${context.state.city} Center`,
               {stats: peopleVisiting, icon: flightLand, color: 'green'}
             )}
             {this.renderCards(`No. of People leaving ${context.state.city} Center`,
               {stats: peopleLeaving, icon: flightTakeoff, color: 'brown-orange'}
             )}
-            {this.renderCards('Average Travel Request Lead Time', {data: (analytics.success ? travelLeadTimeBreakdown.leadTimes : []), chart: true})}
+            {this.renderCards('Average Travel Request Lead Time', {data: (analytics.success ? travelLeadTimeBreakdown.leadTimes : []), chart: true, color: 'orange'})}
           </div>
         )}
       </Fragment>


### PR DESCRIPTION
#### What does this PR do?
Use different colors to display separate charts

#### Description of Task to be completed?
- represent each sector on the pie chart with separate shade
- use different base color for each chart on the analytics dashboard

#### How should this be manually tested?
- Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- checkout this branch - `git checkout bg-fix-card-label-162304867`
- run `yarn start`
- Clone the backend repo - `git clone https://github.com/andela/travel_tool_back.git`
- run `yarn db:rollmigrate` on the backend directory and run `yarn start:dev`
- login to the app as a manager
- go to `http://localhost:3000/dashboard`


#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162305445](https://www.pivotaltracker.com/story/show/162305445)

#### Screenshots (if appropriate)
<img width="1435" alt="screenshot 2018-12-03 at 7 34 24 pm" src="https://user-images.githubusercontent.com/25967737/49393793-86fdb700-f732-11e8-9914-54c976ccdcdd.png">


#### Questions:
None

