### PR TITLE
#162381911 Fix changeroom modal position

### DIFF
--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/TripDetails/TripDetails.scss
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/TripDetails/TripDetails.scss
@@ -94,7 +94,24 @@
       transform-origin: top;
     }
   }
-  &:last-child {
+  &:last-child, &:nth-last-child(2) {
+    .trip-booking-details {
+      transform-origin: bottom;
+      &.details-visible {
+        transform: translateY(-110%) scaleY(1);
+        &.translateX {
+          transform: translateY(-110%) scaleY(1) translateX(-100%);
+        }
+      }
+      &.details-hidden {
+        transform: translateY(-110%) scaleY(0);
+        &.translateX {
+          transform: translateY(-110%) scaleY(0) translateX(-90%);
+        }
+      }
+    }
+  }
+  &:first-child {
     .trip-booking-details {
       transform-origin: bottom;
       &.details-visible {


### PR DESCRIPTION
#### What does this PR do?
This PR fixed the issue with the positioning of the changeroom modal on the timeline.


#### Description of Task to be completed?
- Ensure that the changeroom modal is fully visible for every approved request for the guesthouse.
- Ensure that none of the modal is hidden by any other elements on the page

#### How should this be manually tested?
- Using your terminal, clone this repo -``` git clone https://github.com/andela/travel_tool_front.git``` 
- Checkout to `bg-fix-changeroom-modal-position-162381911`
- Using your terminal, clone this repo -``` git clone https://github.com/andela/travel_tool_back.git``` 
- Checkout to `develop`
- Assign yourself the `Manager` role by changing your roleId to 50319 in the `UserRoles` table
- Make a return trip request using yourself as the manager to the destination used.
- Assign yourself the `Travel Administrator` role by changing your roleId to 29187 in the `UserRoles` table
- Start the application using 'make start'
- Navigate to the `Residence` tab then click `Manage`
- Click on the guesthouse you booked the trip To.
- You should view the request you made. Try changing the room and the modal should be well visible.
- Try changing the room to different rooms and check the position the changeroom modal appears for each.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162381911](https://www.pivotaltracker.com/story/show/162381911)

#### Screenshots (if appropriate)
- Initially 
<img width="1440" alt="screenshot 2018-12-04 at 16 15 31" src="https://user-images.githubusercontent.com/12511966/49444325-e1088600-f7df-11e8-8fad-49792e194531.png">
- After fix
<img width="1440" alt="screenshot 2018-12-04 at 16 16 28" src="https://user-images.githubusercontent.com/12511966/49444366-fda4be00-f7df-11e8-9964-921562b7f774.png">


#### Questions:
N/A