### PR TITLE
#162421358 Fix manager change on request approval bug

### DIFF
--- a/src/components/Forms/NewRequestForm/FormFieldsets/SubmitArea.jsx
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/SubmitArea.jsx
@@ -3,8 +3,8 @@ import {PropTypes} from 'prop-types';
 import ButtonLoadingIcon from '../../ButtonLoadingIcon';
 
 const SubmitArea = (props) => {
-  const { hasBlankFields,sameOriginDestination, onCancel, send, modalType, onEditCancel, selection, loading } = props;
-
+  const { hasBlankFields,sameOriginDestination, onCancel, send, modalType, 
+    onEditCancel, selection, loading, disableOnChangeProfile } = props;
   return (
     <fieldset>
       <div className={selection ? `submit-area submit-area--${selection}` : 'submit-area'}>
@@ -17,7 +17,7 @@ const SubmitArea = (props) => {
               Cancel
             </button>
           )}
-        <button type="submit" disabled={hasBlankFields || loading || sameOriginDestination} className="bg-btn bg-btn--active" id="submit">
+        <button type="submit" disabled={hasBlankFields || loading || (sameOriginDestination && disableOnChangeProfile)} className="bg-btn bg-btn--active" id="submit">
           <ButtonLoadingIcon isLoading={loading} buttonText={send} />
         </button>
       </div>
@@ -34,6 +34,7 @@ SubmitArea.propTypes = {
   onEditCancel: PropTypes.func,
   selection: PropTypes.string,
   loading: PropTypes.bool,
+  disableOnChangeProfile: PropTypes.bool.isRequired
 };
 
 SubmitArea.defaultProps = {

--- a/src/components/Forms/NewRequestForm/NewRequestForm.jsx
+++ b/src/components/Forms/NewRequestForm/NewRequestForm.jsx
@@ -518,6 +518,13 @@ class NewRequestForm extends PureComponent {
   renderForm = () => {
     const { errors, values, hasBlankFields, selection, sameOriginDestination} = this.state;
     const { modalType, creatingRequest } = this.props;
+    const { requestOnEdit } = this.props;
+    const { name, gender, department, role, manager, trips } = requestOnEdit;
+    const { name: stateName, manager: stateManager, gender: stateGender, 
+      department: stateDepartment, role: stateRole} = values;
+    const disableOnChangeProfile = (name === stateName && gender === stateGender && department === stateDepartment 
+     && role === stateRole && manager === stateManager)
+      ? true : false;
     return (
       <FormContext
         targetForm={this}
@@ -541,6 +548,7 @@ class NewRequestForm extends PureComponent {
             sameOriginDestination={sameOriginDestination}
             selection={selection}
             loading={creatingRequest}
+            disableOnChangeProfile={disableOnChangeProfile}
             send={
               modalType === 'edit request' ? 'Update Request' : 'Send Request'
             }


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the approvals bug on updating manager on the edit request form

#### Description of Task to be completed?
- On editing the manager for an open request the manager should see the approval on his `Approvals` page

#### How should this be manually tested?
* Clone the repos: ``` https://github.com/andela/travel_tool_front ``` and ``` https://github.com/andela/travel_tool_back ```.
* cd into their respective directories ```travel_tool_front``` and ```travel_tool_back```.
* On the frontend and backend checkout `bg-fix-manager-bug-on-edit-162421358` branch.
* Start the backend by running the `$yarn run start:dev`
* Start the frontend by running `$yarn start`
* Login and create a new request.
* On the newly created request click on the ellipsis and edit it.
* Change the manager and update the request.
* The request should appear on the newly assigned managers `Approvals` page and not the former manager.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162421358](https://www.pivotaltracker.com/story/show/162421358)

#### Screenshots (if appropriate)


#### Questions: