### PR TITLE
#162126795 End to End tests for Manager can view right items on approvals page

### DIFF
--- a/cypress/fixtures/approvals/approval.json
+++ b/cypress/fixtures/approvals/approval.json
@@ -1,0 +1,53 @@
+{
+    "success": true,
+    "message": "Approvals retrieved successfully",
+    "approvals": [
+      {
+        "id": "CVEgPxX1q",
+        "name": "Ronald Ndirangu",
+        "tripType": "return",
+        "manager": "Ronald Ndirangu",
+        "gender": "Male",
+        "department": "IT",
+        "role": "Software developer",
+        "status": "Open",
+        "userId": "-LOmrkv2HPmwdZvwvec7",
+        "picture": "https://lh6.googleusercontent.com/--MWn6ZsbsqY/AAAAAAAAAAI/AAAAAAAAAAw/IDxtzW5nRwM/photo.jpg?sz=50",
+        "createdAt": "2018-12-10T14:21:31.792Z",
+        "updatedAt": "2018-12-10T14:21:31.792Z",
+        "deletedAt": null,
+        "trips": [
+          {
+            "id": "wbYixF-791",
+            "origin": "Nairobi, Kenya",
+            "destination": "Lagos, Nigeria",
+            "departureDate": "2019-01-01",
+            "returnDate": "2019-01-05",
+            "checkStatus": "Not Checked In",
+            "checkInDate": null,
+            "checkOutDate": null,
+            "lastNotifyDate": null,
+            "notificationCount": 0,
+            "travelCompletion": "false",
+            "createdAt": "2018-12-10T14:21:31.798Z",
+            "updatedAt": "2018-12-10T14:21:31.798Z",
+            "deletedAt": null,
+            "bedId": 6001,
+            "requestId": "CVEgPxX1q"
+          }
+        ],
+        "travelCompletion": "0% complete"
+      }
+    ],
+    "meta": {
+      "count": {
+        "open": 1,
+        "past": 0
+      },
+      "pagination": {
+        "pageCount": 1,
+        "currentPage": 1,
+        "dataCount": 1
+      }
+    }
+  }

--- a/cypress/integration/component/Approvals/approval.spec.js
+++ b/cypress/integration/component/Approvals/approval.spec.js
@@ -1,0 +1,56 @@
+describe('Approvals', () => {
+  before(() => {
+    cy.server();
+    cy.route('GET', 'http://127.0.0.1:5000/api/v1/approvals',
+      'fixture:approvals/approval');
+  });
+
+  describe('Managers approval page', () => {
+    before(() => {
+      cy.authenticateUser();
+      cy.visit('/requests/my-approvals');
+    });
+
+    it('displays the approvals header', () => {
+      cy
+        .get('.PageHeader span.title')
+        .contains('APPROVALS');
+    });
+
+    it('displays the All button', () => {
+      cy
+        .get('#all-button')
+        .contains('All');
+    });
+
+    it('displays the Pending Approvals button', () => {
+      cy
+        .get('#open-button')
+        .contains('Pending Approvals');
+    });
+
+    it('displays the Past Approvals button', () => {
+      cy
+        .get('#past-button')
+        .contains('Past Approvals');
+    });
+
+    it('displays the Items per page text', () => {
+      cy
+        .get('.cell-items-per-page-text')
+        .contains('Items per page');
+    });
+
+    it('displays pre-populated value of 10 on select drop down', () => {
+      cy
+        .get('.dropdown__input')
+        .contains('10');
+    });
+
+    it('displays a component that shows travel request for the manager\'s approval', () => {
+      cy
+        .get('.table__row > .pl-sm-100')
+        .contains('Ronald Ndirangu');
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Adds end-to-end test for approvals page for the scenario when a manager has a pending approval

#### Description of Task to be completed?
- Add end-to-end tests to confirm visibility of necessary items
- Add fixture to mock data when a manager has a pending approval

#### How should this be manually tested?
- Open the terminal  
- Run `yarn end2end` to run the test with browser mode
- When redirected to the browser, select `component/Approvals/approval.spec.js`
- The tests should run and pass
- To run test only in the console, run `yarn end2end:headless` 

#### Any background context you want to provide?
- Ensure both the frontend and backend servers are running

#### What are the relevant pivotal tracker stories?
[#162126795](https://www.pivotaltracker.com/story/show/162126795)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A