### PR TITLE
#162375845 Test to ensure that roles are enforced with Travela roles

### DIFF
--- a/cypress/integration/component/UserRoles/assign-role.spec.js
+++ b/cypress/integration/component/UserRoles/assign-role.spec.js
@@ -1,0 +1,43 @@
+describe('User Roles(assign role to user)', () => {
+  beforeEach(() => {
+    cy.authenticateUser();
+  });
+
+  describe('Assign user', () => {
+    beforeEach(() => {
+      cy.server();
+      cy.visit('settings/roles/10948');
+    });
+
+    it('shows the add user form', () => {
+      cy.get('.action-btn').click();
+      cy.get('.modal').should('exist');
+    });
+
+    it('shows error toast if email is not an andela email', () => {
+      cy.openAndFillRoleForm('hans@gmail.com');
+      cy.get('.toast').should('be.visible');
+      cy.get('.toast').should('contain', 'Only Andela Email address allowed');
+    });
+
+    it('shows error toast if user has already been assigned role', () => {
+      cy.openAndFillRoleForm('travela-test@andela.com');
+      cy.get('.toast').should('be.visible');
+      cy.get('.toast').should('contain', 'User already has this role');
+    });
+
+    it('shows error toast if user email does not exist', () => {
+      cy.openAndFillRoleForm('nonexistent.email@andela.com');
+      cy.get('.toast').should('be.visible');
+      cy.get('.toast').should('contain', 'Email does not exist');
+    });
+
+    it('shows success toast if user is successfully assigned role', () => {
+      cy.openAndFillRoleForm('john.doe@andela.com');
+      cy.get('.toast').should('be.visible');
+      cy.get('.toast').should('contain', 'User has been added');
+      cy.url().should('include', '/settings/roles/10948')
+    });
+  });
+
+});

--- a/cypress/integration/component/UserRoles/user-role.spec.js
+++ b/cypress/integration/component/UserRoles/user-role.spec.js
@@ -1,0 +1,11 @@
+describe('User Role', () => {
+  before(() => {
+    cy.authenticateUser();
+    cy.visit('/settings/roles');
+  });
+
+  it('displays the user roles header', () => {
+    cy.get('.PageHeader span.title').contains('USER ROLES');
+    cy.get('.mdl-data-table').should('exist');
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -4,7 +4,6 @@ Cypress.Commands.add('authenticateUser', (token = testToken) => {
   cy.setCookie('jwt-token', token);
 });
 
-
 Cypress.Commands.add('uploadFile', (filePath,fileType) => {
   cy.fixture(filePath).then((logo) => {
     cy.get('input[type=file]').then(($input) => {
@@ -20,4 +19,11 @@ Cypress.Commands.add('uploadFile', (filePath,fileType) => {
         });
     });
   });
+});
+
+Cypress.Commands.add('openAndFillRoleForm', (email) => {
+  cy.get('.action-btn').click();
+  cy.get('.form-input > input')
+    .type(email);
+  cy.get('#submit').click();
 });


### PR DESCRIPTION
#### What does this PR do?


#### Description of Task to be completed?
- add end to end test for user roles
- check if user roles page renders correctly

#### How should this be manually tested?

##### Backend
- Clone the backend repo - `git clone https://github.com/andela/travel_tool_back.git`
- Checkout to this branch `git checkout ch-e2e-user-roles-162375845`
- Run the command below on your terminal to rollback, migrate and seed e2e data to your database
`yarn db:rollback && yarn db:migrate && yarn db:seed:e2e`
- run `yarn start:dev`

##### Frontend
- Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- checkout this branch - `git checkout ch-e2e-user-roles-162375845`
- run `yarn start`
- Open a new terminal
- Run `yarn end2end` to run the test with browser mode
- When redirected to the browser, select the following
	- 'component/UserRoles/assign-role.spec.js'
	- 'component/UserRoles/user-role.spec.js'
- The tests should run and pass

#### Any background context you want to provide?
- You should first sign in with the Travela test user and add the token to your `cypress.env.json` file.
- If you want to re-run the tests above you would need to re-run the migrate and seed step on the backend as specified above.

#### What are the relevant pivotal tracker stories?
[#162375845](https://www.pivotaltracker.com/story/show/162375845)

#### Screenshots (if appropriate)
None

#### Questions:
None