### PR TITLE
#162604565 Fix bug with new request form crashing app

### DIFF
--- a/src/components/Forms/NewRequestForm/NewRequestForm.jsx
+++ b/src/components/Forms/NewRequestForm/NewRequestForm.jsx
@@ -529,7 +529,7 @@ class NewRequestForm extends PureComponent {
 
 
     const { requestOnEdit } = this.props;
-    const { name, gender, department, role, manager } = requestOnEdit;
+    const { name, gender, department, role, manager } = requestOnEdit || {};
     const { name: stateName, manager: stateManager, gender: stateGender,
       department: stateDepartment, role: stateRole} = values;
     const disableOnChangeProfile = (name === stateName && gender === stateGender && department === stateDepartment


### PR DESCRIPTION
#### What does this PR do?
This PR ensures the app doesn't crash when you open the new request form.

#### Description of Task to be completed?
- When you click on the id of a request on the verifications page and go to the requests page and create a new request.

#### How should this be manually tested?
- Using your terminal, clone this repo -``` git clone https://github.com/andela/travel_tool_front.git``` 
- Checkout to `bg-fx-request-form-crashing-162604565`
- Using your terminal, clone this repo -``` git clone https://github.com/andela/travel_tool_back.git``` 
- Checkout to `develop`
- Assign yourself the `Manager`, `Travel Admin` and `Requester` role by changing your roleId in the `UserRoles` table.
- Make `New Request` and assign yourself as the manager.
- Approve it and update the request with the relevant travel checklist items.
- Navigate to the `Requests` page and click the `New Request` button.
- The app should not crash.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162604565](https://www.pivotaltracker.com/story/show/162604565)

#### Screenshots (if appropriate)


#### Questions: