### PR TITLE
#162698516 Fix accommodation dropdown inconsistency for one way trips

### DIFF
--- a/src/components/Forms/NewRequestForm/FormFieldsets/TravelDetailsItem.jsx
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/TravelDetailsItem.jsx
@@ -34,7 +34,7 @@ class TravelDetailsItem extends Component {
     const departureDate = (Moment(values[`departureDate-${itemId}`]).isSame(trip.departureDate));
     const arrivalDate = (Moment(values[`arrivalDate-${itemId}`]).isSame(trip.returnDate));
     const genderCheck = values.gender === gender;
-    return (origin && destination && departureDate && arrivalDate && genderCheck);
+    return (origin && destination && departureDate && genderCheck || arrivalDate);
   }
 
   getRawBedChoices = (modalType, values, beds) => {


### PR DESCRIPTION
#### What does this PR do?
fix inconsistent accommodation dropdown list

#### Description of Task to be completed?
- make "arrival date" validation optional for one-way trips

#### How should this be manually tested?
- Clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- checkout this branch - `git checkout bg-fix-accomodation-dropdown-162698516`
- run `yarn start`
- login to the app
- create a new travel request for a one-way trip and select `hotel booking` for accommodation.
- Edit the request and change `hotel booking` to an available room.
- Click the request to view the details and confirm that it has been updated
- Open the edit request modal once more. The available rooms option should be prepopulated with the last booking you selected

#### Any background context you want to provide?


#### What are the relevant pivotal tracker stories?
[#162698516](https://www.pivotaltracker.com/story/show/162698516)

#### Screenshots (if appropriate)
None

#### Questions:
None