### PR TITLE
#162711373 change ticket number to flight number

### DIFF
--- a/src/components/TravelCheckList/SubmissionsUtils.jsx
+++ b/src/components/TravelCheckList/SubmissionsUtils.jsx
@@ -167,7 +167,7 @@ class SubmissionsUtils extends Component {
                 'arrivalTime', tripId, arrivalTime
               )}
               {this.renderTicketInput(
-                'text', 'e.g KQ 532', 'Ticket Number',
+                'text', 'e.g KQ 532', 'Flight Number',
                 'ticketNumber', tripId, ticketNumber
               )}
               {this.renderTicketInput(
@@ -189,7 +189,7 @@ class SubmissionsUtils extends Component {
                   'returnTime', tripId, returnTime
                 )}
                 {this.renderTicketInput(
-                  'text', 'e.g KQ 532', 'Return Ticket Number',
+                  'text', 'e.g KQ 532', 'Return Flight Number',
                   'returnTicketNumber', tripId, returnTicketNumber
                 )}
                 {this.renderTicketInput(


### PR DESCRIPTION
#### What does this PR do?
This PR changes ticket number to flight number in the trip planner modal

#### Description of Task to be completed?
Currently, the field for entering Flight Number in the trip planner model is named `Ticket Number`
This PR changes the name of that field to `Flight Number`

#### How should this be manually tested?
- Clone the repo
    `git clone https://github.com/andela/travel_tool_front.git`
 - Switch to the project directory
   `cd travel_tool_front`
 - Checkout the **ch-change-ticket-number-to-flight-number-162711373** branch
   `git checkout ch-change-ticket-number-to-flight-number-162711373`
 - Start the server
   - `yarn start` or `make start` *if you have docker*
 - Navigate to [travela](http://travela-local.andela.com:3000/) in your browser and log in with your Andela account. 
 - Under `Requests`, create a new request.
 - Approve the new request
 - Click on `Travel Checklist` in the request menu
 - A `Travel Checklist` model should be displayed with the third field named `Flight Number`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162711373](https://www.pivotaltracker.com/story/show/162711373)

#### Screenshots (if appropriate)
<img width="987" alt="screen shot 2018-12-18 at 17 55 23" src="https://user-images.githubusercontent.com/38077368/50162003-471bff80-02ee-11e9-9389-3bbc1880243f.png">


#### Questions:
None