### PR TITLE
#162728852 Fix dashboard components

### DIFF
--- a/src/components/AnalyticsCard/index.scss
+++ b/src/components/AnalyticsCard/index.scss
@@ -21,6 +21,7 @@
     line-height: 20px;
     margin: 0;
     padding: 20px 0;
+    font-family: "DIN Pro";
   }
 
   &__stats {

--- a/src/components/AnalyticsReport/index.jsx
+++ b/src/components/AnalyticsReport/index.jsx
@@ -12,7 +12,7 @@ export default class AnalyticsReport extends Component {
     const { fetchDepartmentTrips, fetchReadiness } = this.props;
     fetchDepartmentTrips({filterBy: 'month', type: 'json'});
     fetchReadiness({page: '1', limit: '9', type:'json', travelFlow: 'inflow'});
-  
+
   }
 
   getDepartmentTripsCSV = () => {
@@ -52,7 +52,7 @@ export default class AnalyticsReport extends Component {
     return (
       <div id="no-records" className="analyticsReport__report-details">
         <br />
-        <p className="analyticsReport__text-center">No records found</p>
+        <p className="analyticsReport__text-center">No data to display</p>
       </div>
     );
   }
@@ -66,7 +66,7 @@ export default class AnalyticsReport extends Component {
       </div>
     );
   }
-  
+
   renderTripDetailsHeader = () => {
     return (
       <Fragment>
@@ -85,6 +85,7 @@ export default class AnalyticsReport extends Component {
       </Fragment>
     );
   }
+
   render() {
     const { departmentTrips, readiness, fetchReadiness, exportReadiness } = this.props;
     const { report, loading, error } = departmentTrips;
@@ -103,14 +104,14 @@ export default class AnalyticsReport extends Component {
               {
                 this.renderTripDetailsHeader()
               }
-              {report 
+              {report
               && report.length > 0 && !loading &&
               report.map(item => this.renderTripsDetails(item))}
-              {error 
+              {error
                 ? (
                   <p className="dashboard-component__error-text--style">
                     Oops! An error occurred in retrieving this data
-                  </p> 
+                  </p>
                 )
                 : (report && !report.length && this.renderNotFound())}
             </Fragment>

--- a/src/components/TravelCalendar/index.jsx
+++ b/src/components/TravelCalendar/index.jsx
@@ -133,7 +133,7 @@ class TravelCalendar extends PureComponent {
         <div className="demo-card-wide mdl-card mdl-shadow--2dp error-msg">
           <p className={`${!notFoundError && 'dashboard-component__error-text--style'}`}>
             {notFoundError
-              ? 'No records found' 
+              ? 'No data to display'
               : 'Oops! An error occurred in retrieving this data'
             }
           </p>

--- a/src/components/TravelReadiness/__tests__/travelReadiness.test.js
+++ b/src/components/TravelReadiness/__tests__/travelReadiness.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import TravelReadiness  from '../index';
 import travelReadinessData from '../__mocks__/travelReadinessMockData';
+import AnalyticsPagination from '../../Pagination/AnalyticsPagination';
 
 const defaultProps = {
   readiness: {
@@ -93,7 +94,7 @@ describe('Test suite for Travel Readiness Component', () => {
     exportBtn.simulate('click');
     expect(defaultProps.exportReadiness).toHaveBeenCalled();
   });
-  
+
   it('should obtain next page when handlePagination is called', () => {
     const newWrapper = mount(<TravelReadiness {...defaultProps} />);
     const nextbtn = newWrapper.find('#Next');
@@ -111,5 +112,12 @@ describe('Test suite for Travel Readiness Component', () => {
     newProps.readiness.isLoading = true;
     wrapper.setProps({newProps});
     expect(wrapper.find('TravelReadinessPlaceholder').length).toBe(1);
+  });
+  it('should not render the pagination component if no data exists', () => {
+    let newProps = { ...defaultProps }
+    newProps.readiness.readiness = [];
+    newProps.readiness.pagination.dataCount = 0;
+    wrapper = setup(newProps);
+    expect(wrapper.find(AnalyticsPagination).exists()).toBeFalsy();
   });
 });

--- a/src/components/TravelReadiness/index.jsx
+++ b/src/components/TravelReadiness/index.jsx
@@ -36,10 +36,10 @@ class TravelReadiness extends PureComponent {
   }
 
   renderPagination = (readiness) => {
-    if(readiness){
-      const {pagination} = readiness;
+    const {pagination} = readiness;
+    if(pagination && pagination.dataCount > 0){
       return (
-        <AnalyticsPagination 
+        <AnalyticsPagination
           pagination={pagination}
           handlePagination={this.handlePagination}
         />


### PR DESCRIPTION
#### What does this PR do?
Fixes card titles fonts, travel readiness pagination and message for no data on the dashboard page

#### Description of Task to be completed?
- show Travel Readiness pagination only if data exists
- Set analytics card title fonts to match mockups
- display a consistent message on all cards when no data is available.

#### How should this be manually tested?
- clone the repo - `git clone https://github.com/andela/travel_tool_front.git`
- checkout this branch - `git checkout bg-fix-dashboard-layout-162728852`
- run `yarn start`
- clone the backend repo - `git clone https://github.com/andela/travel_tool_back.git`
- on the backend directory run `yarn db:rollmigrate` the run `yarn start:dev`
- login to the app on your browser
- assign yourself the `Travel Adminstrator` role using Postico
- navigate to the dashboard page
- ensure you have no `Travel Readiness` data.
- ensure you have no data for `Average Travel Duration`
- you should be able to see the card titles on the dashboard page should displaying the `Din Pro` font style
- the `Travel Readiness` card should not have the pagination component on display since there is no data
- the `Travel Readiness` card should only show the pagination component when there is available data
- The message when there is no data to display in any of the cards should be `No data to display`

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162728852](https://www.pivotaltracker.com/story/show/162728852)

#### Screenshots (if appropriate)
<img width="1439" alt="screenshot 2018-12-19 at 10 28 53 am" src="https://user-images.githubusercontent.com/25967737/50211529-25b42580-0379-11e9-8065-2c60414a1536.png">
<img width="1440" alt="screenshot 2018-12-19 at 10 29 01 am" src="https://user-images.githubusercontent.com/25967737/50211531-264cbc00-0379-11e9-9c4b-7d99485b4e21.png">
<img width="1438" alt="screenshot 2018-12-19 at 10 30 09 am" src="https://user-images.githubusercontent.com/25967737/50211532-264cbc00-0379-11e9-953e-68fe442850b0.png">


#### Questions:
None