### PR TITLE
#162711180 Fix accommodation option for Round Trips

### DIFF
--- a/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/TravelDetailsItem.test.js
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/TravelDetailsItem.test.js
@@ -100,6 +100,13 @@ describe('Test Suite for <TravelDetailsItem />', () => {
     const wrapper = setup(newProps);
     expect(props.renderInput).toHaveBeenCalledTimes(106);
   });
+
+  it('should render properly if selection is multi', () => {
+    const newProps = { ...props };
+    newProps.selection = 'multi';
+    const wrapper = setup(newProps);
+    expect(props.renderInput).toHaveBeenCalled();
+  });
 });
 
 

--- a/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/__snapshots__/TravelDetails.test.js.snap
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/__snapshots__/TravelDetails.test.js.snap
@@ -202,9 +202,9 @@ exports[`<TravelDetails /> should match snapshot 1`] = `
       selection="multi"
       values={
         Object {
-          "arrivalDate-1": "2019-10-29T23:00:00.000Z",
+          "arrivalDate-1": "2019-10-30T00:00:00.000Z",
           "bed-1": 1,
-          "departureDate-1": "2019-10-19T23:00:00.000Z",
+          "departureDate-1": "2019-10-20T00:00:00.000Z",
           "destination-1": "Lagos",
           "gender": "Male",
         }

--- a/src/components/Forms/NewRequestForm/NewRequestForm.jsx
+++ b/src/components/Forms/NewRequestForm/NewRequestForm.jsx
@@ -52,6 +52,14 @@ class NewRequestForm extends PureComponent {
   componentDidMount() {
     const { modalType } = this.props;
     if (modalType === 'edit request') {
+      const { trips } = this.state;
+      trips.map(eachTrip => {
+        if (eachTrip.accommodationType === 'Not Required') {
+          eachTrip.bedId = -2;
+        } else if (eachTrip.accommodationType === 'Hotel Booking') {
+          eachTrip.bedId = -1;
+        }
+      });
       this.handleEditForm();
     }
   }

--- a/src/components/Forms/NewRequestForm/NewRequestForm.scss
+++ b/src/components/Forms/NewRequestForm/NewRequestForm.scss
@@ -248,4 +248,3 @@ h1 {
 form .form-input .room-dropdown .select-menu {
   top: 25px;
 }
-

--- a/src/components/RequestsModal/RequestModalHelper.js
+++ b/src/components/RequestsModal/RequestModalHelper.js
@@ -15,12 +15,12 @@ export default class RequestModalHelper {
   static getRequestTripsDetails(requestData) {
     const {trips, tripType, createdAt} = requestData;
     const requestTripsDetails = trips && trips.map(trip => {
-      const tripDetails = { createdAt, tripType, ...trip, };
+      const tripDetails = { createdAt, tripType, ...trip };
       return <TripDetails key={trip.id} tripDetails={tripDetails} />;
     });
     return requestTripsDetails;
   }
-  
+
   static renderStatusAsBadge(status) {
     const style = `request__status--${!status ? '' : status.toLowerCase()}`;
     return (

--- a/src/components/RequestsModal/TripDetails/index.jsx
+++ b/src/components/RequestsModal/TripDetails/index.jsx
@@ -50,13 +50,18 @@ export default class TripDetails extends PureComponent {
       returnDate,
       destination,
       origin,
-      tripType
+      tripType,
+      accommodationType,
     } = tripDetails;
-    let accomodationDetails='Hotel Booking';
+    let accomodationDetails='';
+
     if(beds){
       const {rooms:{roomName, guestHouses:{houseName}}, bedName } = beds;
       accomodationDetails = `${houseName}, ${roomName}, ${bedName}`;
+    } else {
+      accomodationDetails = accommodationType;
     }
+
     return (
       <div className={`modal__modal-trip-details ${tripType}`}>
         {this.renderTripDetails(

--- a/src/components/Timeline/RoomsGeomWrapper/BedGeomWrapper/__tests__/__snapshots__/BedGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/BedGeomWrapper/__tests__/__snapshots__/BedGeomWrapper.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<BedGeomWrapper /> renders properly 1`] = `
 >
   <TripGeometry
     key="trip-id-1"
-    timelineStartDate={"2018-11-30T23:00:00.000Z"}
+    timelineStartDate={"2018-12-01T00:00:00.000Z"}
     timelineViewType="month"
     trip={
       Object {

--- a/src/components/Timeline/RoomsGeomWrapper/RoomGeomWrapper/__tests__/__snapshots__/RoomGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/RoomGeomWrapper/__tests__/__snapshots__/RoomGeomWrapper.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`<RoomGeomWrapper /> renders properly 1`] = `
     </TimelineBarWrapper>
   </div>
   <BedGeomWrapper
-    timelineStartDate={"2018-11-30T23:00:00.000Z"}
+    timelineStartDate={"2018-12-01T00:00:00.000Z"}
     timelineViewType="month"
     tripDayWidth={31}
   />

--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
@@ -15,7 +15,11 @@ exports[`<TripGeometry /> renders correctly 1`] = `
   <TimelineBar
     customStyle={
       Object {
+<<<<<<< HEAD
         "background": "hsl(266,52%,73%)",
+=======
+        "background": "hsl(141,68%,59%)",
+>>>>>>> fix(requests): remove accommodation for multicity
       }
     }
     tripDayWidth={31}
@@ -31,7 +35,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       className="geom-trip geom-trip--inner"
       style={
         Object {
-          "background": "hsl(266,62%,53%)",
+          "background": "hsl(141,78%,39%)",
           "width": "100%",
         }
       }

--- a/src/components/Timeline/RoomsGeomWrapper/__tests__/__snapshots__/RoomsGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/__tests__/__snapshots__/RoomsGeomWrapper.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`<RoomsGeomWrapper /> renders properly 1`] = `
     editMaintenance={Object {}}
     key="room-id-1"
     status={false}
-    timelineStartDate={"2018-11-30T23:00:00.000Z"}
+    timelineStartDate={"2018-12-01T00:00:00.000Z"}
     timelineViewType="month"
     tripDayWidth={31}
   />

--- a/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
+++ b/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
@@ -208,7 +208,7 @@ exports[`<Timeline /> renders correctly 1`] = `
             },
           ]
         }
-        timelineStartDate={"2018-11-30T23:00:00.000Z"}
+        timelineStartDate={"2018-12-01T00:00:00.000Z"}
         timelineViewType="month"
         tripDayWidth={0}
       />
@@ -381,7 +381,7 @@ exports[`<Timeline /> renders the weekly view correctly 1`] = `
             },
           ]
         }
-        timelineStartDate={"2018-11-30T23:00:00.000Z"}
+        timelineStartDate={"2018-12-01T00:00:00.000Z"}
         timelineViewType="week"
         tripDayWidth={0}
       />
@@ -579,7 +579,7 @@ exports[`<Timeline /> renders the year view correctly 1`] = `
             },
           ]
         }
-        timelineStartDate={"2018-11-30T23:00:00.000Z"}
+        timelineStartDate={"2018-12-01T00:00:00.000Z"}
         timelineViewType="year"
         tripDayWidth={0}
       />

--- a/src/redux/reducers/__tests__/requests.test.js
+++ b/src/redux/reducers/__tests__/requests.test.js
@@ -16,6 +16,7 @@ describe('Requests Reducer', () => {
   describe('Fetch Requests Reducer', () => {
     const initialState = {
       requestData: {
+        accommodationType: '',
         trips: [],
         comments: []
       },

--- a/src/redux/reducers/requests.js
+++ b/src/redux/reducers/requests.js
@@ -23,10 +23,11 @@ import {
 const initialState = {
   requestData: {
     trips: [],
-    comments: []
+    comments: [],
+    accommodationType: ''
   },
   requestOnEdit: {},
-  comments: []
+  comments: [],
 };
 
 let editedRequestIndex, comments;


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the bugs on the request page for multi-city requests.

#### Description of Task to be completed?
* Make the `Not Required` accommodation option available.
* Make it the default placeholder for roundtrips.
* Ensure roundtrips where `Not Required` was selected displays it when it's viewed.

#### How should this be manually tested?
- Clone both repositories with ```git clone https://github.com/andela/travel_tool_front ``` and ```git clone https://github.com/andela/travel_tool_back ```
- CD into ```travel_tool_back ```  for the back-end and ```travel_tool_front ```  for the front-end

##### For the Backend
- Checkout to the branch ```bg-accommodation-availability-multicity-162711180``` for the back-end.
- Run ```yarn db:rollmigrate``` to update your database due to the changes that were made
- Start up the back-end ```yarn start:dev```.
- When you create a user with your front end. Make sure you give them the following roles.
- For these, you should have the roles of ```Requester```, ```Manager``` and ```Travel Admin```

#### For the Frontend
 - Checkout the **bg-accommodation-availability-multicity-162711180** branch
   `git checkout bg-accommodation-availability-multicity-162711180`
 - Install dependencies and start the server as stated in the ReadMe on this repository.
   - `make start` *if you have docker*
   - `yarn install` then `yarn start` *if you do not have docker*
 - Start the [backend](https://github.com/andela/travel_tool_back) of this project.
 - Navigate to [travela](http://travela-local.andela.com:3000/) in your browser and log in with your Andela account. 
- Navigate to [travela requests](http://travela-local.andela.com:3000/requests) in your browser.
 - Attempt to add a new request.
 - Fill in all your personal details.

####
 For Roundtrips
 - Select Multi-city trips.
 - Create an entry where the initial location is the same as the final 'Travel to' location.
 - The accommodation option should have `Not Required` as a placeholder for Roundtrips.
 - Select the `Not Required` option.
 - If you view the request the appropriate option should be displayed.
 - If you attempt to edit the request, the appropriate option should be preloaded.

#### 
For others
 - Select Return or one- way
 - Create a request.
 - `Not Required should be one of the accommodation options.`
 - Select the `Not Required` option.
 - If you view the request the appropriate option should be displayed.
 - If you attempt to edit the request, the appropriate option should be preloaded.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
* [Delivers #162711180](https://www.pivotaltracker.com/story/show/162711180)

#### Screenshots (if appropriate)
* Before Fix 
<img width="1180" alt="screen shot 2018-12-18 at 5 44 08 pm" src="https://user-images.githubusercontent.com/18615287/50168857-a7aa3d00-02ec-11e9-8291-230672e7ac4f.png">


* After Fix 
<img width="1178" alt="screen shot 2018-12-19 at 4 20 47 pm" src="https://user-images.githubusercontent.com/18615287/50229313-52ccfc00-03aa-11e9-84cf-c40411244627.png">


<img width="1177" alt="screen shot 2018-12-19 at 4 21 03 pm" src="https://user-images.githubusercontent.com/18615287/50229323-595b7380-03aa-11e9-8ffe-575a4f8c9664.png">


<img width="1177" alt="screen shot 2018-12-19 at 4 21 22 pm" src="https://user-images.githubusercontent.com/18615287/50229347-6aa48000-03aa-11e9-9be7-af2671337348.png">


<img width="759" alt="screen shot 2018-12-19 at 4 21 38 pm" src="https://user-images.githubusercontent.com/18615287/50229361-72642480-03aa-11e9-8bfd-d389cc971bed.png">



#### Questions:
N/A