### PR TITLE
#162726866 Ensure user role is checked before content loads

### DIFF
--- a/src/components/CalendarRange/__tests__/__snapshots__/CalendarRange.test.js.snap
+++ b/src/components/CalendarRange/__tests__/__snapshots__/CalendarRange.test.js.snap
@@ -199,7 +199,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
         >
           <input
             readOnly={true}
-            value="Dec 17, 2018"
+            value="Dec 20, 2018"
           />
         </span>
         <span
@@ -208,7 +208,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
         >
           <input
             readOnly={true}
-            value="Dec 17, 2018"
+            value="Dec 20, 2018"
           />
         </span>
       </div>
@@ -603,7 +603,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                     </span>
                   </button>
                   <button
-                    className="rdrDay rdrDayDisabled rdrDayWeekend rdrDayEndOfWeek"
+                    className="rdrDay rdrDayWeekend rdrDayEndOfWeek"
                     onBlur={[Function]}
                     onFocus={[Function]}
                     onKeyDown={[Function]}
@@ -618,7 +618,6 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                         "color": "#3d91ff",
                       }
                     }
-                    tabIndex={-1}
                     type="button"
                   >
                     <span
@@ -630,7 +629,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                     </span>
                   </button>
                   <button
-                    className="rdrDay rdrDayDisabled rdrDayWeekend rdrDayStartOfWeek"
+                    className="rdrDay rdrDayWeekend rdrDayStartOfWeek"
                     onBlur={[Function]}
                     onFocus={[Function]}
                     onKeyDown={[Function]}
@@ -645,7 +644,6 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                         "color": "#3d91ff",
                       }
                     }
-                    tabIndex={-1}
                     type="button"
                   >
                     <span
@@ -657,7 +655,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                     </span>
                   </button>
                   <button
-                    className="rdrDay rdrDayDisabled"
+                    className="rdrDay"
                     onBlur={[Function]}
                     onFocus={[Function]}
                     onKeyDown={[Function]}
@@ -672,7 +670,6 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                         "color": "#3d91ff",
                       }
                     }
-                    tabIndex={-1}
                     type="button"
                   >
                     <span

--- a/src/components/DashboardHeader/__tests__/__snapshots__/index.test.js.snap
+++ b/src/components/DashboardHeader/__tests__/__snapshots__/index.test.js.snap
@@ -247,7 +247,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
             >
               <input
                 readOnly={true}
-                value="Dec 17, 2018"
+                value="Dec 20, 2018"
               />
             </span>
             <span
@@ -256,7 +256,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
             >
               <input
                 readOnly={true}
-                value="Dec 17, 2018"
+                value="Dec 20, 2018"
               />
             </span>
           </div>
@@ -651,7 +651,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                         </span>
                       </button>
                       <button
-                        className="rdrDay rdrDayDisabled rdrDayWeekend rdrDayEndOfWeek"
+                        className="rdrDay rdrDayWeekend rdrDayEndOfWeek"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onKeyDown={[Function]}
@@ -666,7 +666,6 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                             "color": "#3d91ff",
                           }
                         }
-                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -678,7 +677,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                         </span>
                       </button>
                       <button
-                        className="rdrDay rdrDayDisabled rdrDayWeekend rdrDayStartOfWeek"
+                        className="rdrDay rdrDayWeekend rdrDayStartOfWeek"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onKeyDown={[Function]}
@@ -693,7 +692,6 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                             "color": "#3d91ff",
                           }
                         }
-                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -705,7 +703,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                         </span>
                       </button>
                       <button
-                        className="rdrDay rdrDayDisabled"
+                        className="rdrDay"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onKeyDown={[Function]}
@@ -720,7 +718,6 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                             "color": "#3d91ff",
                           }
                         }
-                        tabIndex={-1}
                         type="button"
                       >
                         <span

--- a/src/components/Forms/ProfileForm/_tests_/ProfileForm.test.jsx
+++ b/src/components/Forms/ProfileForm/_tests_/ProfileForm.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProfileForm from '../index';
+import  ProfileForm  from '../index';
 
 describe ('<ProfileForm />', () =>{
   let wrapper, onSubmit;
@@ -64,4 +64,9 @@ describe ('<ProfileForm />', () =>{
     expect(onSubmit).toHaveBeenCalledTimes(0);
   });
 
+  it('submits the updated profile details', () => {
+    wrapper.setState({hasBlankFields: false});
+    wrapper.find('button').first().simulate('click');
+    expect(props.getUserData).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -122,3 +122,4 @@ ProfileForm.defaultProps = {
 };
 
 export default ProfileForm;
+

--- a/src/components/RequestsModal/TripDetails/__tests__/__snapshots__/TripDetails.test.jsx.snap
+++ b/src/components/RequestsModal/TripDetails/__tests__/__snapshots__/TripDetails.test.jsx.snap
@@ -66,7 +66,7 @@ exports[`<TripDetails /> should render correctly 1`] = `
       <div
         className="modal__trip-detail-text"
       >
-        17 Dec 2018
+        20 Dec 2018
       </div>
     </div>
   </div>

--- a/src/components/RequestsModal/__tests__/__snapshots__/RequestsModal.test.js.snap
+++ b/src/components/RequestsModal/__tests__/__snapshots__/RequestsModal.test.js.snap
@@ -25,7 +25,7 @@ exports[` 1`] = `
       Date submitted: 
     </span>
     <b>
-      17 Dec 2018
+      20 Dec 2018
     </b>
   </span>
 </div>
@@ -56,7 +56,7 @@ exports[`Render RequestsModal component Connected RequestDetailsModal component 
       Date submitted: 
     </span>
     <b>
-      17 Dec 2018
+      20 Dec 2018
     </b>
   </span>
 </div>

--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
@@ -8,14 +8,14 @@ exports[`<TripGeometry /> renders correctly 1`] = `
     Object {
       "length": 7,
       "stayPercentage": "100%",
-      "tripTimelineOffsetLeft": -10850,
+      "tripTimelineOffsetLeft": -10943,
     }
   }
 >
   <TimelineBar
     customStyle={
       Object {
-        "background": "hsl(122,35%,74%)",
+        "background": "hsl(94,40%,68%)",
       }
     }
     tripDayWidth={31}
@@ -23,7 +23,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       Object {
         "length": 7,
         "stayPercentage": "100%",
-        "tripTimelineOffsetLeft": -10850,
+        "tripTimelineOffsetLeft": -10943,
       }
     }
   >
@@ -31,7 +31,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       className="geom-trip geom-trip--inner"
       style={
         Object {
-          "background": "hsl(122,45%,54%)",
+          "background": "hsl(94,50%,48%)",
           "width": "100%",
         }
       }

--- a/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
+++ b/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
@@ -121,12 +121,12 @@ exports[`<Timeline /> renders correctly 1`] = `
         key="15"
       />
       <div
-        className="timeline__segment current month-view"
+        className="timeline__segment  month-view"
         data-segment-label="17"
         key="16"
       />
       <div
-        className="timeline__segment current month-view"
+        className="timeline__segment  month-view"
         data-segment-label="18"
         key="17"
       />
@@ -136,7 +136,7 @@ exports[`<Timeline /> renders correctly 1`] = `
         key="18"
       />
       <div
-        className="timeline__segment  month-view"
+        className="timeline__segment current month-view"
         data-segment-label="20"
         key="19"
       />

--- a/src/helper/permissions/__tests__/permissions.test.js
+++ b/src/helper/permissions/__tests__/permissions.test.js
@@ -1,0 +1,25 @@
+import checkUserPermission from '../index';
+import {MANAGER, REQUESTER, SUPER_ADMINISTRATOR, TRAVEL_TEAM_MEMBER} from '../../roles';
+
+const history = {
+  push: jest.fn(),
+};
+describe('checkUserPermissions', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should redirect if the user does not have permissions', () => {
+    const result = checkUserPermission(history,[SUPER_ADMINISTRATOR], [REQUESTER, MANAGER]);
+
+    expect(result).toBe(false);
+    expect(history.push).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return true if the user has permissions', () => {
+    const result = checkUserPermission(history,[REQUESTER, SUPER_ADMINISTRATOR, MANAGER], [TRAVEL_TEAM_MEMBER,SUPER_ADMINISTRATOR]);
+    expect(result).toBe(true);
+    expect(history.push).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/helper/permissions/index.js
+++ b/src/helper/permissions/index.js
@@ -1,9 +1,10 @@
 const checkUserPermission = (history, allowedRoles, userRoles) => {
   const hasPermission = userRoles.some(role => allowedRoles.includes(role));
-  if (!hasPermission) {
+  if (!hasPermission && allowedRoles.length !== 0) {
     history.push('/requests');
+    return false;
   } else {
-    return hasPermission;
+    return true;
   }
 };
 

--- a/src/helper/roles.js
+++ b/src/helper/roles.js
@@ -1,0 +1,13 @@
+export const SUPER_ADMINISTRATOR = 'Super Administrator';
+export const TRAVEL_ADMINISTRATOR = 'Travel Administrator';
+export const TRAVEL_TEAM_MEMBER = 'Travel Team Member';
+export const REQUESTER= 'Requester';
+export const MANAGER = 'Manager';
+
+export const ALL = [
+  SUPER_ADMINISTRATOR,
+  TRAVEL_TEAM_MEMBER,
+  TRAVEL_ADMINISTRATOR,
+  REQUESTER,
+  MANAGER
+];

--- a/src/hoc/Layout/__tests__/Layout.test.jsx
+++ b/src/hoc/Layout/__tests__/Layout.test.jsx
@@ -5,6 +5,7 @@ import {MemoryRouter} from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import createSagaMiddleware from 'redux-saga';
 import { Layout } from '..';
+import {REQUESTER} from '../../../helper/roles';
 
 const middleware = [createSagaMiddleware];
 const mockStore = configureStore(middleware);
@@ -27,52 +28,61 @@ const initialState = {
 
 const store = mockStore(initialState);
 
+const props = {
+  children: {},
+  location: {},
+  notifications: [],
+  user: {
+    UserInfo: {
+      name: 'Tomato Jos',
+      picture: 'http://picture.com/gif',
+      getCurrentUserRole: [REQUESTER]
+    }
+  },
+  getUserData: jest.fn(),
+};
+
 describe('Layout component', () => {
-  xdescribe('<Layout />', () => {
-    const props = {
-      notifications: []
-    };
+  describe('<Layout />', () => {
 
-    let wrapper;
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Layout {...props} location={{}}>
+            <div>
+              Test Content
+            </div>
+          </Layout>
+        </MemoryRouter>
+      </Provider>
+    );
 
-    beforeAll(() => {
-      wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter>
-            <Layout {...props} location={{}}>
-              <div>
-                Test Content
-              </div>
-            </Layout>
-          </MemoryRouter>
-        </Provider>
-      );
-    });
 
     it('should render all the components except the notification pane', () => {
       expect(wrapper.find('.sidebar').length).toBe(1);// LeftSideBar
       expect(wrapper.find('.notification').hasClass('hide')).toEqual(true);
-      wrapper.unmount();
     });
 
     it('should display the notification pane when the notification icon gets clicked', () => {
       const notificationIcon = wrapper.find('.navbar__navbar-notification');
-      notificationIcon.simulate('click');
+      if( wrapper.find('.notification.hide').exists()){
+        notificationIcon.simulate('click');
+      }
       expect(wrapper.find('.notification').exists()).toBeTruthy();
       expect(wrapper.find('.notification .hide').exists()).toBeFalsy();
       expect(wrapper.find('.sidebar').hasClass('hide')).toEqual(true);
       expect(wrapper.find('NavBar').exists()).toBeTruthy();
-      wrapper.unmount();
     });
 
     it('should close the notification pane when the close icon is clicked', () => {
       const closeIcon = wrapper.find('.notifications-header__close-btn');
       const openNotificationIcon = wrapper.find('.navbar__navbar-notification');
-      openNotificationIcon.simulate('click');
+      if( wrapper.find('.notification.hide').exists()){
+        openNotificationIcon.simulate('click');
+      }
       expect(wrapper.find('.notification.hide').exists()).toBeFalsy();
       closeIcon.simulate('click');
       expect(wrapper.find('.notification.hide').exists()).toBeTruthy();
-      wrapper.unmount();
     });
 
     it.skip('should log the user out when the logout button is clicked', () => {
@@ -84,11 +94,6 @@ describe('Layout component', () => {
   });
 
   describe('Layout Shallow', () => {
-    const props = {
-      notifications: [],
-      children: {},
-      location: {}
-    };
 
     let shallowWrapper;
 

--- a/src/hoc/Layout/__tests__/__snapshots__/Layout.test.jsx.snap
+++ b/src/hoc/Layout/__tests__/__snapshots__/Layout.test.jsx.snap
@@ -52,9 +52,7 @@ exports[`Layout component Layout Shallow should render layout component correctl
         >
           <div
             className="rp-requests "
-          >
-            <Component />
-          </div>
+          />
         </div>
       </div>
       <div

--- a/src/hoc/__tests__/__snapshots__/authHoc.test.js.snap
+++ b/src/hoc/__tests__/__snapshots__/authHoc.test.js.snap
@@ -1,26 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component: isAuthenticated User Protected Routes test suite Redirects user to homepage if they are not authenticated 1`] = `
-<Connect(Requests)
-  auth={
-    Object {
-      "isAuthenticated": false,
-      "user": null,
-    }
-  }
-  getUserData={[Function]}
-  history={
-    Object {
-      "push": [Function],
-    }
-  }
-  isAuthenticated={false}
-  user={
-    Object {
-      "UserInfo": Object {
-        "name": "John Doe",
-      },
-    }
-  }
-/>
-`;
+exports[`Component: isAuthenticated User Protected Routes test suite Redirects user to homepage if they are not authenticated 1`] = `""`;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -16,6 +16,12 @@ import ConnectedChecklist from '../views/Checklist';
 import ConnectedRoleDetails from '../views/RoleDetails';
 import ConnectedDocuments from '../views/Documents';
 import NotFound from '../views/ErrorPages';
+import {
+  TRAVEL_ADMINISTRATOR,
+  SUPER_ADMINISTRATOR,
+  TRAVEL_TEAM_MEMBER,
+  MANAGER
+} from '../helper/roles';
 
 
 const Routes = () => (
@@ -36,22 +42,48 @@ const Routes = () => (
           <Route
             path="/dashboard"
             exact
-            component={RequireAuth(ConnectedDashboard)}
+            component={
+              RequireAuth(
+                ConnectedDashboard,
+                TRAVEL_ADMINISTRATOR,
+                SUPER_ADMINISTRATOR,
+                TRAVEL_TEAM_MEMBER
+              )
+            }
           />
           <Route
             path="/requests/my-approvals"
             exact
-            component={RequireAuth(ConnectedApprovals)}
+            component={
+              RequireAuth(
+                ConnectedApprovals,
+                SUPER_ADMINISTRATOR,MANAGER
+              )
+            }
           />
           <Route
             path="/requests/my-verifications"
             exact
-            component={RequireAuth(ConnectedVerifications)}
+            component={
+              RequireAuth(
+                ConnectedVerifications,
+                SUPER_ADMINISTRATOR,
+                TRAVEL_TEAM_MEMBER,
+                TRAVEL_ADMINISTRATOR
+              )
+            }
           />
           <Route
             path="/requests/my-verifications/:requestId"
             exact
-            component={RequireAuth(ConnectedVerifications)}
+            component={
+              RequireAuth(
+                ConnectedVerifications,
+                SUPER_ADMINISTRATOR,
+                TRAVEL_TEAM_MEMBER,
+                TRAVEL_ADMINISTRATOR
+              )
+            }
           />
           <Route
             path="/requests"
@@ -61,7 +93,12 @@ const Routes = () => (
           <Route
             path="/settings/roles"
             exact
-            component={RequireAuth(ConnectedRole)}
+            component={
+              RequireAuth(
+                ConnectedRole,
+                SUPER_ADMINISTRATOR
+              )
+            }
           />
           <Route
             path="/requests/:requestId"
@@ -81,7 +118,13 @@ const Routes = () => (
           <Route
             path="/residence/manage"
             exact
-            component={RequireAuth(ConnectedAccommodation)}
+            component={
+              RequireAuth(
+                ConnectedAccommodation,
+                SUPER_ADMINISTRATOR,
+                TRAVEL_ADMINISTRATOR
+              )
+            }
           />
           <Route
             path="/residence/manage/guest-houses/:guestHouseId"
@@ -96,12 +139,24 @@ const Routes = () => (
           <Route
             path="/checklists"
             exact
-            component={RequireAuth(ConnectedChecklist)}
+            component={
+              RequireAuth(
+                ConnectedChecklist,
+                SUPER_ADMINISTRATOR,
+                TRAVEL_ADMINISTRATOR
+              )
+            }
           />
           <Route
             path="/settings/roles/:roleId"
             exact
-            component={RequireAuth(ConnectedRoleDetails)}
+            component={
+              RequireAuth(
+                ConnectedRoleDetails,
+                SUPER_ADMINISTRATOR,
+                TRAVEL_ADMINISTRATOR
+              )
+            }
           />
           <Route
             path="/documents"

--- a/src/views/Accommodation/index.jsx
+++ b/src/views/Accommodation/index.jsx
@@ -13,7 +13,6 @@ import {
   restoreDisabledAccommodation
 } from '../../redux/actionCreator/accommodationActions';
 import WithLoadingCentreGrid from '../../components/CentreGrid';
-import checkUserPermission from '../../helper/permissions';
 import ButtonLoadingIcon from '../../components/Forms/ButtonLoadingIcon';
 import './Accommodation.scss';
 
@@ -109,11 +108,7 @@ export class Accommodation extends Component {
   }
 
   render() {
-    const { guestHouses, isLoading, accommodationError, isLoaded, getCurrentUserRole, history, disabledGuestHouses, modal } = this.props;
-    if (isLoaded) {
-      const allowedRoles = ['Travel Administrator', 'Super Administrator'];
-      checkUserPermission(history, allowedRoles, getCurrentUserRole );
-    }
+    const { guestHouses, isLoading, accommodationError, disabledGuestHouses, modal } = this.props;
     return (
       <Fragment>
         {this.renderAccommodationPanelHeader()}
@@ -137,7 +132,6 @@ export class Accommodation extends Component {
 Accommodation.propTypes = {
   history: PropTypes.shape({}).isRequired,
   shouldOpen: PropTypes.bool.isRequired,
-  getCurrentUserRole: PropTypes.array.isRequired,
   openModal: PropTypes.func.isRequired,
   createAccommodation: PropTypes.func.isRequired,
   createAccommodationLoading: PropTypes.bool.isRequired,
@@ -159,7 +153,6 @@ Accommodation.propTypes = {
   accommodationError: PropTypes.string,
   fetchAccommodation: PropTypes.func.isRequired,
   editAccommodation: PropTypes.func.isRequired,
-  isLoaded: PropTypes.bool,
   modal: PropTypes.func.isRequired,
   restoreDisabledAccommodation: PropTypes.func.isRequired,
 };
@@ -170,7 +163,6 @@ Accommodation.defaultProps = {
   accommodationError: '',
   isLoading: false,
   modalType: '',
-  isLoaded: false
 };
 
 const actionCreators = {

--- a/src/views/Approvals/index.jsx
+++ b/src/views/Approvals/index.jsx
@@ -6,7 +6,6 @@ import { openModal, closeModal } from '../../redux/actionCreator/modalActions';
 import WithLoadingTable from '../../components/Table';
 import Base from '../Base';
 import Utils from '../../helper/Utils';
-import checkUserPermission from '../../helper/permissions';
 import NotFound from '../ErrorPages';
 
 export class Approvals extends Base {
@@ -111,12 +110,7 @@ export class Approvals extends Base {
   }
 
   render() {
-    const {approvals, getCurrentUserRole, history, match} = this.props;
-    const { isLoading } = approvals;
-    if (!isLoading && getCurrentUserRole.length > 0) {
-      const allowedRoles = ['Super Administrator', 'Manager'];
-      checkUserPermission(history, allowedRoles, getCurrentUserRole);
-    }
+    const {approvals, match} = this.props;
     const { requestId } = this.state;
     const filteredReqId = approvals.approvals.filter(approval => approval.id === requestId);
 

--- a/src/views/CheckIn/__tests__/__snapshots__/CheckIn.test.js.snap
+++ b/src/views/CheckIn/__tests__/__snapshots__/CheckIn.test.js.snap
@@ -36,7 +36,7 @@ Array [
                     <td
                         className="mdl-data-table__cell--non-numeric checkInTable__data residence__text"
                     >
-                        17th Dec - 4th Oct 2025
+                        20th Dec - 4th Oct 2025
                     </td>
                     <td
                         className="mdl-data-table__cell--non-numeric checkInTable__data__column table__button-column"

--- a/src/views/Checklist/index.jsx
+++ b/src/views/Checklist/index.jsx
@@ -12,7 +12,6 @@ import './index.scss';
 import RestoreChecklistItem from '../../components/modal/RestoreChecklistModal/RestoreChecklistModal';
 import DeleteRequestForm from '../../components/Forms/DeleteRequestForm/DeleteRequestForm';
 import Preloader from '../../components/Preloader/Preloader';
-import checkUserPermission from '../../helper/permissions';
 
 
 export class Checklist extends Component {
@@ -220,11 +219,6 @@ export class Checklist extends Component {
   }
   
   render() {
-    const { isLoading, getCurrentUserRole, history } = this.props;
-    if (!isLoading && getCurrentUserRole.length > 0) {
-      const allowedRoles = ['Super Administrator', 'Travel Administrator'];
-      checkUserPermission(history, allowedRoles, getCurrentUserRole);
-    }
     return (
       <Fragment>
         {this.renderChecklistForm()}
@@ -258,8 +252,6 @@ Checklist.propTypes = {
   modalType: PropTypes.string, checklistItems: PropTypes.array.isRequired,
   deletedChecklistItems: PropTypes.array, currentUser: PropTypes.object.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  getCurrentUserRole: PropTypes.array.isRequired,
-  history: PropTypes.object.isRequired
 };
 
 Checklist.defaultProps = {

--- a/src/views/Dashboard/__tests__/.test.js
+++ b/src/views/Dashboard/__tests__/.test.js
@@ -58,11 +58,4 @@ describe('<Dashboard />', () => {
       });
     expect(mapper.getCurrentUserRole[0]).toEqual('Travel Admin');
   });
-
-  it('should call the checkUserPermission method if isLoaded is true', () => {
-    const newProps = { ...props, isLoaded: true };
-    const newWrapper = shallow(<Dashboard {...newProps} />);
-    expect(newWrapper.length).toBe(1);
-    expect(checkUserPermission).toHaveBeenCalled();
-  });
 });

--- a/src/views/Dashboard/__tests__/Dashboard.test.js
+++ b/src/views/Dashboard/__tests__/Dashboard.test.js
@@ -64,11 +64,4 @@ describe('<Dashboard />', () => {
       });
     expect(mapper.getCurrentUserRole[0]).toEqual('Travel Admin');
   });
-
-  it('should call the checkUserPermission method if isLoaded is true', () => {
-    const newProps = { ...props, isLoaded: true };
-    const newWrapper = shallow(<Dashboard {...newProps} />);
-    expect(newWrapper.length).toBe(1);
-    expect(checkUserPermission).toHaveBeenCalled();
-  });
 });

--- a/src/views/Dashboard/index.jsx
+++ b/src/views/Dashboard/index.jsx
@@ -10,7 +10,6 @@ import {fetchCalendarAnalytics, downloadCalendarAnalytics} from '../../redux/act
 import FilterContext, { Consumer } from './DashboardContext/FilterContext';
 import AnalyticsReport from '../../components/AnalyticsReport';
 import DashboardHeader from '../../components/DashboardHeader';
-import checkUserPermission from '../../helper/permissions';
 import ConnectedAnalytics from '../Analytics';
 import TravelCalendar from '../../components/TravelCalendar';
 import './index.scss';
@@ -19,12 +18,8 @@ export class Dashboard extends Component {
 
   render() {
     const { fetchDepartmentTrips, departmentTrips, fetchReadiness,readiness,
-      history, getCurrentUserRole, isLoaded, exportReadiness, travelCalendar, fetchCalendarAnalytics,
+      exportReadiness, travelCalendar, fetchCalendarAnalytics,
       downloadCalendarAnalytics, downloadAnalytics } = this.props;
-    if (isLoaded) {
-      const allowedRoles = ['Travel Administrator', 'Super Administrator', 'Travel Team Member'];
-      checkUserPermission(history, allowedRoles, getCurrentUserRole);
-    }
     return (
       <div id="dashboard">
         <FilterContext>

--- a/src/views/Role/index.jsx
+++ b/src/views/Role/index.jsx
@@ -13,7 +13,6 @@ import {
   updateRole
 } from '../../redux/actionCreator/roleActions';
 import './Role.scss';
-import checkUserPermission from '../../helper/permissions';
 
 export class Role extends Component {
   state = {
@@ -98,11 +97,6 @@ export class Role extends Component {
   }
 
   render() {
-    const { getCurrentUserRole, history, isLoaded } = this.props;
-    if (isLoaded) {
-      const allowedRoles = ['Super Administrator'];
-      checkUserPermission(history, allowedRoles, getCurrentUserRole );
-    }
     return (
       <Fragment>
         {this.renderRoleForm()}
@@ -125,12 +119,10 @@ Role.propTypes = {
   roleErrors: PropTypes.string,
   addRole: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,
-  getCurrentUserRole: PropTypes.array.isRequired,
   history: PropTypes.shape({}).isRequired,
   openModal: PropTypes.func.isRequired,
   shouldOpen: PropTypes.bool.isRequired,
   modalType: PropTypes.string,
-  isLoaded: PropTypes.bool,
   isAddingRole: PropTypes.bool,
   updateRole: PropTypes.func.isRequired
 };
@@ -139,7 +131,6 @@ Role.defaultProps = {
   isLoading: false,
   roleErrors: '',
   modalType: '',
-  isLoaded: false,
   isAddingRole: false
 };
 

--- a/src/views/RoleDetails/index.js
+++ b/src/views/RoleDetails/index.js
@@ -1,21 +1,20 @@
 import React, {Component, Fragment} from 'react';
-import { connect } from 'react-redux';
-import { PropTypes } from 'prop-types';
+import {connect} from 'react-redux';
+import {PropTypes} from 'prop-types';
 import WithLoadingRoleDetailsTable from '../../components/RoleDetailsTable';
 import PageHeader from '../../components/PageHeader';
 import Modal from '../../components/modal/Modal';
-import { NewUserRoleForm } from '../../components/Forms';
-import { openModal, closeModal } from '../../redux/actionCreator/modalActions';
+import {NewUserRoleForm} from '../../components/Forms';
+import {closeModal, openModal} from '../../redux/actionCreator/modalActions';
 import {
-  fetchRoleUsers,
-  putRoleData,
   deleteUserRole,
+  fetchRoleUsers,
   hideDeleteRoleModal,
+  putRoleData,
   showDeleteRoleModal
 } from '../../redux/actionCreator/roleActions';
-import { fetchCenters, updateUserCenter } from '../../redux/actionCreator/centersActions';
+import {fetchCenters, updateUserCenter} from '../../redux/actionCreator/centersActions';
 import './RoleDetails.scss';
-import checkUserPermission from '../../helper/permissions';
 import NotFound from '../ErrorPages';
 
 export class RoleDetails extends Component {
@@ -149,16 +148,10 @@ export class RoleDetails extends Component {
 
   render() {
     const {
-      getCurrentUserRole,
-      history,
-      isLoaded,
       isFetching,
       roleName,
       error
     } = this.props;
-    let allowed = ['Travel Administrator', 'Super Administrator'];
-    isLoaded ?
-      checkUserPermission(history, allowed, getCurrentUserRole ) : null;
     return (
       <Fragment>
         { !isFetching && !roleName && error &&<NotFound redirectLink="/settings/roles" /> }
@@ -193,7 +186,6 @@ RoleDetails.propTypes = {
   centers: PropTypes.array,
   putRoleData: PropTypes.func.isRequired,
   updateUserCenter: PropTypes.func.isRequired,
-  isLoaded: PropTypes.bool,
   deleteModalRoleId: PropTypes.number.isRequired,
   deleteModalState: PropTypes.string.isRequired,
   showDeleteRoleModal: PropTypes.func.isRequired,
@@ -207,7 +199,6 @@ RoleDetails.defaultProps = {
   modalType: '',
   roleName: '',
   centers: [],
-  isLoaded: false
 };
 
 const actionCreators = {

--- a/src/views/UserProfile/index.jsx
+++ b/src/views/UserProfile/index.jsx
@@ -8,6 +8,7 @@ import ProfileForm from '../../components/Forms/ProfileForm';
 import Base from '../Base';
 import { fetchRoleUsers } from '../../redux/actionCreator/roleActions';
 import { getOccupation } from '../../redux/actionCreator/occupationActions';
+import {getUserData} from '../../redux/actionCreator/userActions';
 
 
 class UserProfile extends Base {
@@ -56,7 +57,8 @@ export const mapStateToProps = ({ user, role, occupations}) => ({
 const actionCreators = {
   updateUserProfile,
   fetchRoleUsers,
-  getOccupation
+  getOccupation,
+  getUserData
 };
 export default connect(
   mapStateToProps,

--- a/src/views/Verifications/index.jsx
+++ b/src/views/Verifications/index.jsx
@@ -6,7 +6,6 @@ import { openModal, closeModal } from '../../redux/actionCreator/modalActions';
 import WithLoadingTable from '../../components/Table';
 import Base from '../Base';
 import Utils from '../../helper/Utils';
-import checkUserPermission from '../../helper/permissions';
 import NotFound from '../ErrorPages';
 
 export class Verifications extends Base {
@@ -112,12 +111,7 @@ export class Verifications extends Base {
   }
   
   render() {
-    const { approvals, getCurrentUserRole, history, match } = this.props;
-    const { isLoading } = approvals;
-    if (!isLoading && getCurrentUserRole.length > 0) {
-      const allowedRoles = ['Travel Administrator', 'Super Administrator', 'Travel Team Member'];
-      checkUserPermission(history, allowedRoles, getCurrentUserRole);
-    }
+    const { approvals, match } = this.props;
     const { requestId } = this.state;
     const filteredReqId = approvals.approvals.filter(approval => approval.id === requestId);
 


### PR DESCRIPTION
#### What does this PR do?
- Ensures the credentials for users are checked before the page content loads

#### Description of Task to be completed?
- Protect the routes based on the user's roles
- Ensure the page content loads after the user's role has been verified

#### How should this be manually tested?
- Clone the repo
    `git clone https://github.com/andela/travel_tool_front.git`
 - Switch to the project directory
   `cd travel_tool_front`
 - Checkout the **bg-fix-user-access-162726866** branch
   `git checkout bg-fix-user-access-162726866`
 - Install dependencies and start the server
   - `make start` *if you have docker*
   - `yarn install` then `yarn start` *if you do not have docker*
 - Start the [backend](https://github.com/andela/travel_tool_back) of this project.
 - Navigate to [travela](http://travela-local.andela.com:3000/) in your browser and log in with your Andela account. 
 - Log in as a requester
- Navigate to [settings](http://travela-local.andela.com:3000/settings/roles) in your browser.
- The page will not display the user's roles first. You will be redirected to the requests page.


#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162726866](https://www.pivotaltracker.com/story/show/162726866)

#### Screenshots (if appropriate)
![screenshot 2018-12-19 at 15 08 31 2](https://user-images.githubusercontent.com/25629064/50219352-fa90fc80-039f-11e9-8499-cd48ed9f9ffa.png)
