### PR TITLE
#162784141 fix add checklist model responsiveness

### DIFF
--- a/src/components/Forms/NewChecklistForm/FormFieldSets/newChecklistForm.scss
+++ b/src/components/Forms/NewChecklistForm/FormFieldSets/newChecklistForm.scss
@@ -1,6 +1,7 @@
 form {
   fieldset.add-checklist {
     .input-group{
+      width: 100%;
       span.link-fields-divider{
         padding-left: 7px;
         padding-right: 7px;
@@ -9,6 +10,7 @@ form {
       }
 
       .form-input{
+        margin-left: 0%;
         width: 100%;
         &.link-label-field{
           max-width: 200px;


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the responsiveness of the add travel checklist item model

#### Description of Task to be completed?
Right now, the fields in the modal to add a travel checklist item extend beyond the modal border when the size of the window is reduced.
This PR fixes the issue in that it allows the model and the fields to respond to window size changes properly.

#### How should this be manually tested?
- Clone the repo
    `git clone https://github.com/andela/travel_tool_front.git`
 - Switch to the project directory
   `cd travel_tool_front`
 - Checkout the **bg-fix-add-checklist-responsiveness-162784141** branch
   `git checkout bg-fix-add-checklist-responsiveness-162784141`
 - Start the server
   - `yarn start` or `make start` *if you have docker*
 - Navigate to [travela](http://travela-local.andela.com:3000/) in your browser.
 - Log in as a Travel Administrator. 
 - Navigate to Trip Planner
 - Click the button to Add a Checklist item
 - Adjust the window size to check for responsiveness of the model.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162784141](https://www.pivotaltracker.com/story/show/162784141)

#### Screenshots (if appropriate)
#####Before


#### Questions:
None