### PR TITLE
#162711180 Fix requests date created inconsistency

### DIFF
--- a/src/components/Table/index.jsx
+++ b/src/components/Table/index.jsx
@@ -182,7 +182,7 @@ export class Table extends Component {
           {travelDuration}
         </td>
         <td className="mdl-data-table__cell--non-numeric table__data">
-          {moment(request.departureDate).format('DD MMM YYYY')}
+          {moment(request.updatedAt).format('DD MMM YYYY')}
         </td>
         { this.renderTravelCompletion(type, travelCompletion)}
         <td className="mdl-data-table__cell--non-numeric table__requests__status table__data">


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the requests date created inconsistency

#### Description of Task to be completed?
* Change the value passed to `updatedAt`.

#### How should this be manually tested?
- Clone the front end repository with ```git clone https://github.com/andela/travel_tool_front ``` 
- CD into ```travel_tool_front ``` 
 - Checkout the **bg-fix-requests-date-created-inconsistency-162910388** branch
   `git checkout bg-fix-requests-date-created-inconsistency-162910388`
 - Install dependencies and start the server as stated in the ReadMe on this repository.
   - `make start` *if you have docker*
   - `yarn install` then `yarn start` *if you do not have docker*
 - Start the [backend](https://github.com/andela/travel_tool_back) of this project.
 - Navigate to [travela](http://travela-local.andela.com:3000/) in your browser and log in with your Andela account. 
- Navigate to [travela requests](http://travela-local.andela.com:3000/requests) in your browser.
- Create multiple requests.
- The pre-existing requests should have the correct dates for when they were created.
- The new requests should have the correct date  

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
* [Delivers #162711180](https://www.pivotaltracker.com/story/show/162711180)

#### Screenshots (if appropriate)
* Before Fix 
<img width="1435" alt="screen shot 2019-01-02 at 3 29 22 pm" src="https://user-images.githubusercontent.com/18615287/50596113-68aae880-0ea3-11e9-914a-beb127990fdd.png">


* After Fix 
<img width="1431" alt="screen shot 2019-01-02 at 3 28 51 pm" src="https://user-images.githubusercontent.com/18615287/50596121-719bba00-0ea3-11e9-871f-3dfe4868bc81.png">


#### Questions:
N/A