### PR TITLE
#162813288 Fix profile page inconsistencies

### DIFF
--- a/src/components/CalendarRange/__tests__/__snapshots__/CalendarRange.test.js.snap
+++ b/src/components/CalendarRange/__tests__/__snapshots__/CalendarRange.test.js.snap
@@ -199,7 +199,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
         >
           <input
             readOnly={true}
-            value="Jan 1, 2019"
+            value="Jan 3, 2019"
           />
         </span>
         <span
@@ -208,7 +208,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
         >
           <input
             readOnly={true}
-            value="Jan 1, 2019"
+            value="Jan 3, 2019"
           />
         </span>
       </div>
@@ -993,7 +993,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                     </span>
                   </button>
                   <button
-                    className="rdrDay rdrDayDisabled rdrDayWeekend rdrDayStartOfWeek"
+                    className="rdrDay rdrDayWeekend rdrDayStartOfWeek"
                     onBlur={[Function]}
                     onFocus={[Function]}
                     onKeyDown={[Function]}
@@ -1008,7 +1008,6 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                         "color": "#3d91ff",
                       }
                     }
-                    tabIndex={-1}
                     type="button"
                   >
                     <span
@@ -1020,7 +1019,7 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                     </span>
                   </button>
                   <button
-                    className="rdrDay rdrDayDisabled"
+                    className="rdrDay"
                     onBlur={[Function]}
                     onFocus={[Function]}
                     onKeyDown={[Function]}
@@ -1035,7 +1034,6 @@ exports[`<ButtonGroup /> should render successfully 1`] = `
                         "color": "#3d91ff",
                       }
                     }
-                    tabIndex={-1}
                     type="button"
                   >
                     <span

--- a/src/components/DashboardHeader/__tests__/__snapshots__/index.test.js.snap
+++ b/src/components/DashboardHeader/__tests__/__snapshots__/index.test.js.snap
@@ -247,7 +247,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
             >
               <input
                 readOnly={true}
-                value="Jan 1, 2019"
+                value="Jan 3, 2019"
               />
             </span>
             <span
@@ -256,7 +256,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
             >
               <input
                 readOnly={true}
-                value="Jan 1, 2019"
+                value="Jan 3, 2019"
               />
             </span>
           </div>
@@ -1041,7 +1041,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                         </span>
                       </button>
                       <button
-                        className="rdrDay rdrDayDisabled rdrDayWeekend rdrDayStartOfWeek"
+                        className="rdrDay rdrDayWeekend rdrDayStartOfWeek"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onKeyDown={[Function]}
@@ -1056,7 +1056,6 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                             "color": "#3d91ff",
                           }
                         }
-                        tabIndex={-1}
                         type="button"
                       >
                         <span
@@ -1068,7 +1067,7 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                         </span>
                       </button>
                       <button
-                        className="rdrDay rdrDayDisabled"
+                        className="rdrDay"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onKeyDown={[Function]}
@@ -1083,7 +1082,6 @@ exports[`<DashboardHeader /> renders as expected 1`] = `
                             "color": "#3d91ff",
                           }
                         }
-                        tabIndex={-1}
                         type="button"
                       >
                         <span

--- a/src/components/Forms/FormsAPI/formValidator/index.js
+++ b/src/components/Forms/FormsAPI/formValidator/index.js
@@ -35,9 +35,9 @@ function validate(field)  {
     return !hasBlankFields;
   }
 
-  !values[field] && !isOptional(field, optionalFields)
-    ? (errors[field] = 'This field is required')
-    : (errors[field] = '');
+  errors[field] = !values[field] && !isOptional(field, optionalFields)
+    && 'This field is required';
+
   targetForm.setState(prevState => ({ ...prevState, errors, hasBlankFields}));
   return !hasBlankFields;
 }

--- a/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/__snapshots__/TravelDetails.test.js.snap
+++ b/src/components/Forms/NewRequestForm/FormFieldsets/__tests__/__snapshots__/TravelDetails.test.js.snap
@@ -202,9 +202,9 @@ exports[`<TravelDetails /> should match snapshot 1`] = `
       selection="multi"
       values={
         Object {
-          "arrivalDate-1": "2019-10-30T00:00:00.000Z",
+          "arrivalDate-1": "2019-10-29T21:00:00.000Z",
           "bed-1": 1,
-          "departureDate-1": "2019-10-20T00:00:00.000Z",
+          "departureDate-1": "2019-10-19T21:00:00.000Z",
           "destination-1": "Lagos",
           "gender": "Male",
         }

--- a/src/components/Forms/ProfileForm/ProfileForm.scss
+++ b/src/components/Forms/ProfileForm/ProfileForm.scss
@@ -97,7 +97,7 @@ form.new-profile{
         background-color: #F8F8F8;
       }
       .input button{
-        width: 150px;
+        width: 149px;
       }
       label{
         color: #4F4F4F;

--- a/src/components/Forms/ProfileForm/_tests_/ProfileForm.test.jsx
+++ b/src/components/Forms/ProfileForm/_tests_/ProfileForm.test.jsx
@@ -63,10 +63,4 @@ describe ('<ProfileForm />', () =>{
     const onSubmit = jest.fn();
     expect(onSubmit).toHaveBeenCalledTimes(0);
   });
-
-  it('submits the updated profile details', () => {
-    wrapper.setState({hasBlankFields: false});
-    wrapper.find('button').first().simulate('click');
-    expect(props.getUserData).toHaveBeenCalledTimes(1);
-  });
 });

--- a/src/components/Forms/ProfileForm/index.jsx
+++ b/src/components/Forms/ProfileForm/index.jsx
@@ -28,18 +28,19 @@ class ProfileForm extends PureComponent {
       hideSideBar: false,
       openSearch: false,
       selectedLink: 'settings page',
-      hideOverlay: false
+      hideOverlay: false,
     };
     this.state = { ...this.defaultState };
     this.validate = getDefaultBlanksValidatorFor(this);
   }
 
-  static getDerivedStateFromProps(props, state){
-    const { userData } = props;
-    if(userData !== undefined && state.values.department === ''){
+  componentWillReceiveProps(nextProps){
+    const { userData } = nextProps;
+
+    if(userData !== undefined){
       const { passportName, gender, department, occupation, manager } = userData;
-      return  {
-        ...state,
+      this.setState((prevState) => ({
+        ...prevState,
         values: {
           name: Validator.databaseValueValidator(passportName),
           gender: Validator.databaseValueValidator(gender),
@@ -47,14 +48,13 @@ class ProfileForm extends PureComponent {
           role: Validator.databaseValueValidator(occupation),
           manager: Validator.databaseValueValidator(manager)
         }
-      };
+      }));
     }
-    return null;
   }
 
   submitProfileForm = event => {
     event.preventDefault();
-    const { updateUserProfile, user, getUserData, occupations } = this.props;
+    const { updateUserProfile, user, occupations } = this.props;
 
     const userId = user.UserInfo.id;
     const { values } = this.state;
@@ -64,7 +64,7 @@ class ProfileForm extends PureComponent {
       data.passportName = data.name;
       data.occupation = isValid ? data.role: '';
       updateUserProfile(data, userId, true);
-      getUserData(userId);
+      this.setState({hasBlankFields: true});
     }
   };
 
@@ -82,9 +82,8 @@ class ProfileForm extends PureComponent {
           <ProfileDetails
             values={values}
             managers={managers}
-            hasBlankFields={hasBlankFields}
             occupations={occupations} />
-          {hasBlankFields ? (
+          {hasBlankFields? (
             <div className="submit-area">
               <button
                 type="submit"
@@ -113,7 +112,7 @@ ProfileForm.propTypes = {
   updateUserProfile: PropTypes.func.isRequired,
   managers: PropTypes.array,
   user: PropTypes.object.isRequired,
-  getUserData: PropTypes.func.isRequired,
+  userData: PropTypes.object.isRequired,
   occupations: PropTypes.array
 };
 ProfileForm.defaultProps = {

--- a/src/components/RequestsModal/TripDetails/__tests__/__snapshots__/TripDetails.test.jsx.snap
+++ b/src/components/RequestsModal/TripDetails/__tests__/__snapshots__/TripDetails.test.jsx.snap
@@ -66,7 +66,7 @@ exports[`<TripDetails /> should render correctly 1`] = `
       <div
         className="modal__trip-detail-text"
       >
-        01 Jan 2019
+        03 Jan 2019
       </div>
     </div>
   </div>

--- a/src/components/RequestsModal/__tests__/__snapshots__/RequestsModal.test.js.snap
+++ b/src/components/RequestsModal/__tests__/__snapshots__/RequestsModal.test.js.snap
@@ -25,7 +25,7 @@ exports[` 1`] = `
       Date submitted: 
     </span>
     <b>
-      01 Jan 2019
+      03 Jan 2019
     </b>
   </span>
 </div>
@@ -56,7 +56,7 @@ exports[`Render RequestsModal component Connected RequestDetailsModal component 
       Date submitted: 
     </span>
     <b>
-      01 Jan 2019
+      03 Jan 2019
     </b>
   </span>
 </div>

--- a/src/components/Timeline/RoomsGeomWrapper/BedGeomWrapper/__tests__/__snapshots__/BedGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/BedGeomWrapper/__tests__/__snapshots__/BedGeomWrapper.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`<BedGeomWrapper /> renders properly 1`] = `
 >
   <TripGeometry
     key="trip-id-1"
-    timelineStartDate={"2019-01-01T00:00:00.000Z"}
+    timelineStartDate={"2018-12-31T21:00:00.000Z"}
     timelineViewType="month"
     trip={
       Object {

--- a/src/components/Timeline/RoomsGeomWrapper/RoomGeomWrapper/__tests__/__snapshots__/RoomGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/RoomGeomWrapper/__tests__/__snapshots__/RoomGeomWrapper.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`<RoomGeomWrapper /> renders properly 1`] = `
     </TimelineBarWrapper>
   </div>
   <BedGeomWrapper
-    timelineStartDate={"2019-01-01T00:00:00.000Z"}
+    timelineStartDate={"2018-12-31T21:00:00.000Z"}
     timelineViewType="month"
     tripDayWidth={31}
   />

--- a/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/TripGeometry/__tests__/__snapshots__/TripGeometry.test.jsx.snap
@@ -8,14 +8,14 @@ exports[`<TripGeometry /> renders correctly 1`] = `
     Object {
       "length": 7,
       "stayPercentage": "100%",
-      "tripTimelineOffsetLeft": -11315,
+      "tripTimelineOffsetLeft": -11377,
     }
   }
 >
   <TimelineBar
     customStyle={
       Object {
-        "background": "hsl(312,66%,51%)",
+        "background": "hsl(275,69%,59%)",
       }
     }
     tripDayWidth={31}
@@ -23,7 +23,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       Object {
         "length": 7,
         "stayPercentage": "100%",
-        "tripTimelineOffsetLeft": -11315,
+        "tripTimelineOffsetLeft": -11377,
       }
     }
   >
@@ -31,7 +31,7 @@ exports[`<TripGeometry /> renders correctly 1`] = `
       className="geom-trip geom-trip--inner"
       style={
         Object {
-          "background": "hsl(312,76%,31%)",
+          "background": "hsl(275,79%,39%)",
           "width": "100%",
         }
       }

--- a/src/components/Timeline/RoomsGeomWrapper/__tests__/__snapshots__/RoomsGeomWrapper.test.jsx.snap
+++ b/src/components/Timeline/RoomsGeomWrapper/__tests__/__snapshots__/RoomsGeomWrapper.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`<RoomsGeomWrapper /> renders properly 1`] = `
     editMaintenance={Object {}}
     key="room-id-1"
     status={false}
-    timelineStartDate={"2019-01-01T00:00:00.000Z"}
+    timelineStartDate={"2018-12-31T21:00:00.000Z"}
     timelineViewType="month"
     tripDayWidth={31}
   />

--- a/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
+++ b/src/components/Timeline/__tests__/__snapshots__/Timeline.test.jsx.snap
@@ -41,7 +41,7 @@ exports[`<Timeline /> renders correctly 1`] = `
       className="timeline__body-segments"
     >
       <div
-        className="timeline__segment current month-view"
+        className="timeline__segment  month-view"
         data-segment-label="1"
         key="0"
       />
@@ -51,7 +51,7 @@ exports[`<Timeline /> renders correctly 1`] = `
         key="1"
       />
       <div
-        className="timeline__segment  month-view"
+        className="timeline__segment current month-view"
         data-segment-label="3"
         key="2"
       />
@@ -208,7 +208,7 @@ exports[`<Timeline /> renders correctly 1`] = `
             },
           ]
         }
-        timelineStartDate={"2019-01-01T00:00:00.000Z"}
+        timelineStartDate={"2018-12-31T21:00:00.000Z"}
         timelineViewType="month"
         tripDayWidth={0}
       />
@@ -334,7 +334,7 @@ exports[`<Timeline /> renders the weekly view correctly 1`] = `
       className="timeline__body-segments"
     >
       <div
-        className="timeline__segment current week-view"
+        className="timeline__segment  week-view"
         data-segment-label="Tue 1/1"
         key="0"
       />
@@ -344,7 +344,7 @@ exports[`<Timeline /> renders the weekly view correctly 1`] = `
         key="1"
       />
       <div
-        className="timeline__segment  week-view"
+        className="timeline__segment current week-view"
         data-segment-label="Thu 1/3"
         key="2"
       />
@@ -381,7 +381,7 @@ exports[`<Timeline /> renders the weekly view correctly 1`] = `
             },
           ]
         }
-        timelineStartDate={"2019-01-01T00:00:00.000Z"}
+        timelineStartDate={"2018-12-31T21:00:00.000Z"}
         timelineViewType="week"
         tripDayWidth={0}
       />
@@ -579,7 +579,7 @@ exports[`<Timeline /> renders the year view correctly 1`] = `
             },
           ]
         }
-        timelineStartDate={"2019-01-01T00:00:00.000Z"}
+        timelineStartDate={"2018-12-31T21:00:00.000Z"}
         timelineViewType="year"
         tripDayWidth={0}
       />

--- a/src/redux/actionCreator/userProfileActions.js
+++ b/src/redux/actionCreator/userProfileActions.js
@@ -1,4 +1,4 @@
-import {UPDATE_USER_PROFILE}from '../constants/actionTypes';
+import {UPDATE_PROFILE_SUCCESS, UPDATE_USER_PROFILE} from '../constants/actionTypes';
 
 const updateUserProfile = (userProfileData, userId, showToast) =>(
   {
@@ -8,5 +8,10 @@ const updateUserProfile = (userProfileData, userId, showToast) =>(
     showToast
   });
 
+
+export const updateUserProfileSuccess = response => ({
+  type: UPDATE_PROFILE_SUCCESS,
+  response
+});
 
 export default updateUserProfile;

--- a/src/redux/middleware/UserProfileSaga.js
+++ b/src/redux/middleware/UserProfileSaga.js
@@ -3,6 +3,7 @@ import toast from 'toastr';
 import ProfileApi from '../../services/ProfileApi';
 import apiErrorHandler from '../../services/apiErrorHandler';
 import { UPDATE_USER_PROFILE } from '../constants/actionTypes';
+import {updateUserProfileSuccess} from '../actionCreator/userProfileActions';
 
 export function* postUserProfileDataSagaAsync(action) {
   try {
@@ -13,6 +14,7 @@ export function* postUserProfileDataSagaAsync(action) {
     );
     if (action.showToast){
       toast.success('Profile updated successfully');
+      yield put(updateUserProfileSuccess(response.data));
     }
   } catch (error) {
     const errorMessage = apiErrorHandler(error);

--- a/src/redux/reducers/user.js
+++ b/src/redux/reducers/user.js
@@ -5,6 +5,7 @@ import {
   GET_USER_DATA,
   GET_USER_DATA_SUCCESS,
   GET_USER_DATA_FAILURE,
+  UPDATE_PROFILE_SUCCESS,
 } from '../constants/actionTypes';
 
 const initialState = {
@@ -28,6 +29,13 @@ const user = (state = initialState, action) => {
         .roles.map(role => role.roleName),
       errors: [],
       isLoaded: true
+    };
+  case UPDATE_PROFILE_SUCCESS:
+    return {
+      ...state,
+      getUserData: action.response,
+      currentUser: action.response.result,
+      errors: [],
     };
   case GET_USER_DATA_FAILURE:
     return {

--- a/src/views/CheckIn/__tests__/__snapshots__/CheckIn.test.js.snap
+++ b/src/views/CheckIn/__tests__/__snapshots__/CheckIn.test.js.snap
@@ -36,7 +36,7 @@ Array [
                     <td
                         className="mdl-data-table__cell--non-numeric checkInTable__data residence__text"
                     >
-                        1st Jan - 4th Oct 2025
+                        3rd Jan - 4th Oct 2025
                     </td>
                     <td
                         className="mdl-data-table__cell--non-numeric checkInTable__data__column table__button-column"

--- a/src/views/UserProfile/__tests__/__snapshots__/UserProfile.test.js.snap
+++ b/src/views/UserProfile/__tests__/__snapshots__/UserProfile.test.js.snap
@@ -64,7 +64,7 @@ Array [
                             onBlur={[Function]}
                             onChange={[Function]}
                             type="text"
-                            value="Collins Njau"
+                            value=""
                         />
                         <span
                             className="error"
@@ -101,7 +101,7 @@ Array [
                                 Female
                             </button>
                             <button
-                                className="bg-btn bg-btn--active"
+                                className="bg-btn bg-btn--inactive"
                                 data-value="Male"
                                 key="Male"
                                 name="gender"
@@ -156,15 +156,8 @@ Array [
                                     name="role"
                                     onChange={[Function]}
                                     type="text"
-                                    value="Software Developer"
+                                    value=""
                                 />
-                                <div
-                                    className="hide"
-                                >
-                                    <ul
-                                        className="select-menu select-menu--inactive"
-                                    />
-                                </div>
                             </div>
                         </div>
                         <span
@@ -215,7 +208,7 @@ Array [
                                 role="button"
                                 tabIndex="0"
                                 type="dropdown-select"
-                                value="Talent & Development"
+                                value=""
                             >
                                 <div
                                     className="value"
@@ -225,7 +218,7 @@ Array [
                                           }
                                     }
                                 >
-                                    Talent & Development
+                                     
                                     <div
                                         className="select-dropdown inactive"
                                     >
@@ -338,7 +331,7 @@ Array [
                                 role="button"
                                 tabIndex="0"
                                 type="dropdown-select"
-                                value="Collins"
+                                value=""
                             >
                                 <div
                                     className="value"

--- a/src/views/UserProfile/index.jsx
+++ b/src/views/UserProfile/index.jsx
@@ -23,7 +23,7 @@ class UserProfile extends Base {
 
   render() {
     const { roleUsers, updateUserProfile, user,
-      fetchUserData, getUserData, occupations } = this.props;
+      fetchUserData, occupations } = this.props;
     return (
       <Fragment>
         <h1>PROFILE</h1>
@@ -34,7 +34,6 @@ class UserProfile extends Base {
               updateUserProfile={updateUserProfile}
               userData={fetchUserData && fetchUserData.result}
               user={user}
-              getUserData={getUserData}
               occupations={occupations}
             />
           </div>


### PR DESCRIPTION
#### What does this PR do?
- Fixes the inconsistencies on the profile page

#### Description of Task to be completed?
Ensure the following issues are addressed
- When a user tries to type in their name, the user input is not captured as they type it unless you first select the department.
- When a user selects their gender as the first input, the styling becomes inconsistent (see attached screenshot)
- When a user successfully updates their profile, the success message is rendered as expected but the input dialogue does not update with the user's input hence it is rendered with empty fields unless the user reloads the page

#### How should this be manually tested?
- Clone the repo
    `git clone https://github.com/andela/travel_tool_front.git`
 - Switch to the project directory
   `cd travel_tool_front`
 - Checkout the **bg-profile-page-inconsistencies-162813288** branch
   `git checkout bg-profile-page-inconsistencies-162813288`
 - Install dependencies and start the server
   - `make start` *if you have docker*
   - `yarn install` then `yarn start` *if you do not have docker*
 - Start the [backend](https://github.com/andela/travel_tool_back) of this project.
 - Navigate to [travela](http://travela-local.andela.com:3000/) in your browser and log in with your Andela account. 
 - Log in as a requester
- Navigate to [Profile](http://travela-local.andela.com:3000/settings/profile) in your browser.
- Ensure you are using a profile that is empty
- Enter the user details. 
- You will now be able to start with any of the fields in any order as you wish
1. Name
2. Department
3. Manager
4. Gender
5. Role


#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#162813288](https://www.pivotaltracker.com/story/show/162813288)

### Screenshots (if appropriate)

#### Before
![2019-01-02 23-09-57 2019-01-02 23_12_15](https://user-images.githubusercontent.com/25629064/50610411-f0184c00-0ee3-11e9-9a27-4a9c7ee29686.gif)

#### After
![2019-01-02 23-05-46 2019-01-02 23_06_53](https://user-images.githubusercontent.com/25629064/50610205-25706a00-0ee3-11e9-98c9-7032bf77da3e.gif)
